### PR TITLE
Element ref

### DIFF
--- a/packages/accented/README.md
+++ b/packages/accented/README.md
@@ -22,6 +22,13 @@ TODO: example screenshots, without Accented / with Accented.
 
 ### API
 
+### Iframes
+
+Although axe-core is capable of scanning iframes, Accented doesn’t provide that as a special capability.
+
+Instead, if you wish to scan the document in an iframe, initialize Accented inside the iframed document.
+There should be no interference between the instances of Accented running in the parent and child documents.
+
 ## Frequently asked questions
 
 <!-- TODO: how can this section be better formatted? This probably should be regular sections rather than a Q&A. -->

--- a/packages/accented/src/scanner.ts
+++ b/packages/accented/src/scanner.ts
@@ -1,13 +1,15 @@
 import axe from 'axe-core';
 import TaskQueue from './task-queue.js';
-import issuesToElements from './utils/issuesToElements.js';
+import issuesToElements from './utils/issues-to-elements.js';
 import { enabled, elements } from './state.js';
 
 export default function createScanner(initialDelay: number, throttleDelay: number) {
   const taskQueue = new TaskQueue<Node>(async () => {
     performance.mark('axe-start');
 
-    const result = await axe.run();
+    const result = await axe.run({
+      elementRef: true
+    });
 
     const axeMeasure = performance.measure('axe', 'axe-start');
 

--- a/packages/accented/src/scanner.ts
+++ b/packages/accented/src/scanner.ts
@@ -8,7 +8,14 @@ export default function createScanner(initialDelay: number, throttleDelay: numbe
     performance.mark('axe-start');
 
     const result = await axe.run({
-      elementRef: true
+      elementRef: true,
+      // Although axe-core can perform iframe scanning, I haven't succeeded in it,
+      // and the docs suggest that the axe-core script should be explicitly included
+      // in each of the iframed documents anyway.
+      // It seems preferable to disallow iframe scanning and not report issues in elements within iframes
+      // in the case that such issues are for some reason reported by axe-core.
+      // A consumer of Accented can instead scan the iframed document by calling Accented initialization from that document.
+      iframes: false
     });
 
     const axeMeasure = performance.measure('axe', 'axe-start');

--- a/packages/accented/src/utils/issues-to-elements.ts
+++ b/packages/accented/src/utils/issues-to-elements.ts
@@ -5,12 +5,8 @@ export default function issuesToElements(issues: typeof AxeResults.violations) {
 
   for (const issue of issues) {
     for (const node of issue.nodes) {
-      // TODO: make this work for iframes and Shadow DOM
-      if (typeof node.target[0] === 'string') {
-        const element = document.querySelector(node.target[0]);
-        if (element) {
-          elements.add(element);
-        }
+      if (node.element) {
+        elements.add(node.element);
       }
     }
   }

--- a/packages/accented/src/utils/issues-to-elements.ts
+++ b/packages/accented/src/utils/issues-to-elements.ts
@@ -5,7 +5,14 @@ export default function issuesToElements(issues: typeof AxeResults.violations) {
 
   for (const issue of issues) {
     for (const node of issue.nodes) {
-      if (node.element) {
+      // target.length > 1 means that the issue is in an iframe.
+      // Although axe-core can perform iframe scanning, I haven't succeeded in it,
+      // and the docs suggest that the axe-core script should be explicitly included
+      // in each of the iframed documents anyway.
+      // It seems preferable to disallow iframe scanning and not report issues in elements within iframes
+      // in the case that such issues are for some reason reported by axe-core.
+      // A consumer of Accented can instead scan the iframed document by calling Accented initialization from that document.
+      if (node.element && node.target.length === 1) {
         elements.add(node.element);
       }
     }


### PR DESCRIPTION
* Use element ref provided by axe-core.
* Explicitly disallow scanning in iframes (just in case).