### PR TITLE
Fix: element positioning within transformed elements

### DIFF
--- a/.changeset/thin-cougars-pull.md
+++ b/.changeset/thin-cougars-pull.md
@@ -1,0 +1,5 @@
+---
+"accented": patch
+---
+
+Fix trigger positioning within transformed elements in Safari and Firefox

--- a/packages/accented/src/utils/get-element-position.ts
+++ b/packages/accented/src/utils/get-element-position.ts
@@ -1,18 +1,45 @@
 import type { Position } from '../types';
 
+function getNearestTransformedAncestor(element: Element, win: Window): Element | null {
+  let currentElement: Element | null = element;
+  while (currentElement) {
+    const transform = win.getComputedStyle(currentElement).transform;
+    if (transform !== 'none') {
+      return currentElement;
+    }
+    currentElement = currentElement.parentElement;
+  }
+  return null;
+}
+
 export default function getElementPosition(element: Element, win: Window): Position {
   const rect = element.getBoundingClientRect();
+  const transformedAncestor = getNearestTransformedAncestor(element, win);
+  let top, left, right;
+  // If an element has an ancestor whose transform is not 'none',
+  // fixed positioning works differently.
+  // https://achrafkassioui.com/blog/position-fixed-and-CSS-transforms/
+  if (transformedAncestor) {
+    const transformedAncestorRect = transformedAncestor.getBoundingClientRect();
+    top = rect.top - transformedAncestorRect.top;
+    left = rect.left - transformedAncestorRect.left;
+    right = rect.right - transformedAncestorRect.left;
+  } else {
+    top = rect.top;
+    left = rect.left;
+    right = rect.right;
+  }
   const direction = win.getComputedStyle(element).direction;
   if (direction === 'ltr') {
     return {
-      inlineEndLeft: rect.right,
-      blockStartTop: rect.top,
+      inlineEndLeft: right,
+      blockStartTop: top,
       direction
     };
   } else if (direction === 'rtl') {
     return {
-      inlineEndLeft: rect.left,
-      blockStartTop: rect.top,
+      inlineEndLeft: left,
+      blockStartTop: top,
       direction
     };
   } else {

--- a/packages/devapp/src/index.html
+++ b/packages/devapp/src/index.html
@@ -143,6 +143,11 @@
         </form>
       </section>
 
+      <section style="transform: translateX(0);">
+        <h2>Transformed element</h2>
+        <button class="test-button"></button>
+      </section>
+
       <section>
         <h2>Performance testing</h2>
         <button id="add-one">Add one element with an issue</button>


### PR DESCRIPTION
If an element has an ancestor whose `transform` is not `none`, fixed positioning works differently.

https://achrafkassioui.com/blog/position-fixed-and-CSS-transforms/

Resolves #109 
