### PR TITLE
Measure DOM update performance

### DIFF
--- a/.changeset/lucky-apes-drop.md
+++ b/.changeset/lucky-apes-drop.md
@@ -1,0 +1,5 @@
+---
+"accented": major
+---
+
+Change signature of `callback` by adding the DOM update duration

--- a/packages/accented/README.md
+++ b/packages/accented/README.md
@@ -95,15 +95,19 @@ A function that Accented will call after every scan.
 It accepts a single `params` object with the following properties:
 
 * `elementsWithIssues`: the most up-to-date array of all elements with accessibility issues.
-* `scanDuration`: how long the last scan took, in milliseconds (may be useful for performance tracking).
+* `performance`: runtime performance of the last scan. An object:
+  * `totalBlockingTime`: how long the main thread was blocked by Accented during the last scan, in milliseconds.
+    It’s further divided into the `scan` and `domUpdate` phases.
+  * `scan`: how long the `scan` phase took, in milliseconds.
+  * `domUpdate`: how long the `domUpdate` phase took, in milliseconds.
 
 **Example:**
 
 ```
 accented({
-  callback: ({ elementsWithIssues, scanDuration }) => {
+  callback: ({ elementsWithIssues, performance }) => {
     console.log('Elements with issues:', elementsWithIssues);
-    console.log('Scan duration:', scanDuration);
+    console.log('Total blocking time:', performance.totalBlockingTime);
   }
 });
 ```

--- a/packages/accented/src/accented.ts
+++ b/packages/accented/src/accented.ts
@@ -5,6 +5,7 @@ import createLogger from './logger.js';
 import createScanner from './scanner.js';
 import setupScrollListeners from './scroll-listeners.js';
 import setupResizeListener from './resize-listener.js';
+import setupFullscreenListener from './fullscreen-listener.js';
 import setupIntersectionObserver from './intersection-observer.js';
 import { enabled, extendedElementsWithIssues } from './state.js';
 import deepMerge from './utils/deep-merge.js';
@@ -34,9 +35,9 @@ export type { AccentedOptions, DisableAccented };
  *     wait: 500,
  *     leading: false
  *   },
- *   callback: ({ elementsWithIssues, scanDuration }) => {
+ *   callback: ({ elementsWithIssues, performance }) => {
  *    console.log('Elements with issues:', elementsWithIssues);
- *    console.log('Scan duration:', scanDuration);
+ *    console.log('Total blocking time:', performance.totalBlockingTime);
  *   }
  * });
  */
@@ -95,6 +96,7 @@ export default function accented(options: AccentedOptions = {}): DisableAccented
     const cleanupLogger = output.console ? createLogger() : () => {};
     const cleanupScrollListeners = supportsAnchorPositioning(window) ? () => {} : setupScrollListeners();
     const cleanupResizeListener = supportsAnchorPositioning(window) ? () => {} : setupResizeListener();
+    const cleanupFullscreenListener = supportsAnchorPositioning(window) ? () => {} : setupFullscreenListener();
 
     return () => {
       try {
@@ -105,6 +107,7 @@ export default function accented(options: AccentedOptions = {}): DisableAccented
         cleanupLogger();
         cleanupScrollListeners();
         cleanupResizeListener();
+        cleanupFullscreenListener();
         if (cleanupIntersectionObserver) {
           cleanupIntersectionObserver();
         }

--- a/packages/accented/src/fullscreen-listener.ts
+++ b/packages/accented/src/fullscreen-listener.ts
@@ -1,0 +1,17 @@
+import logAndRethrow from './log-and-rethrow.js';
+import recalculatePositions from './utils/recalculate-positions.js';
+
+export default function setupResizeListener() {
+  const abortController = new AbortController();
+  window.addEventListener('fullscreenchange', () => {
+    try {
+      recalculatePositions();
+    } catch (error) {
+      logAndRethrow(error);
+    }
+  }, { signal: abortController.signal });
+
+  return () => {
+    abortController.abort();
+  };
+};

--- a/packages/accented/src/scanner.ts
+++ b/packages/accented/src/scanner.ts
@@ -23,7 +23,7 @@ export default function createScanner(name: string, axeContext: AxeContext, axeO
 
     try {
 
-      performance.mark('axe-start');
+      performance.mark('scan-start');
 
       win[axeRunningWindowProp] = true;
 
@@ -55,17 +55,27 @@ export default function createScanner(name: string, axeContext: AxeContext, axeO
       }
       win[axeRunningWindowProp] = false;
 
-      const axeMeasure = performance.measure('axe', 'axe-start');
+      const scanMeasure = performance.measure('scan', 'scan-start');
+      const scanDuration = Math.round(scanMeasure.duration);
 
       if (!enabled.value) {
         return;
       }
 
+      performance.mark('dom-update-start');
+
       updateElementsWithIssues(extendedElementsWithIssues, result.violations, window, name);
+
+      const domUpdateMeasure = performance.measure('dom-update', 'dom-update-start');
+      const domUpdateDuration = Math.round(domUpdateMeasure.duration);
 
       callback({
         elementsWithIssues: elementsWithIssues.value,
-        scanDuration: Math.round(axeMeasure.duration)
+        performance: {
+          totalBlockingTime: scanDuration + domUpdateDuration,
+          scan: scanDuration,
+          domUpdate: domUpdateDuration
+        }
       });
     } catch (error) {
       win[axeRunningWindowProp] = false;

--- a/packages/accented/src/types.ts
+++ b/packages/accented/src/types.ts
@@ -42,9 +42,17 @@ type CallbackParams = {
   elementsWithIssues: Array<ElementWithIssues>,
 
   /**
-   * How long the scan took in milliseconds.
+   * * `performance`: runtime performance of the last scan. An object:
+   * * `totalBlockingTime`: how long the main thread was blocked by Accented during the last scan, in milliseconds.
+   *   It’s further divided into the `scan` and `domUpdate` phases.
+   * * `scan`: how long the `scan` phase took, in milliseconds.
+   * * `domUpdate`: how long the `domUpdate` phase took, in milliseconds.
    * */
-  scanDuration: number
+  performance: {
+    totalBlockingTime: number,
+    scan: number,
+    domUpdate: number
+  }
 }
 
 export type Callback = (params: CallbackParams) => void;

--- a/packages/devapp/src/main.ts
+++ b/packages/devapp/src/main.ts
@@ -45,14 +45,16 @@ document.getElementById('remove-button')?.addEventListener('click', () => {
   document.getElementById('button-with-single-issue')?.remove();
 });
 
-setTimeout(() => {
-  const buttonWithManyIssues = document.getElementById('over-2-issues');
-  const status = document.getElementById('issues-updated-status');
-  if (buttonWithManyIssues && status) {
-    buttonWithManyIssues.role = '';
-    status.hidden = false;
-  }
-}, 1000);
+if (searchParams.has('remove-issues-on-timeout')) {
+  setTimeout(() => {
+    const buttonWithManyIssues = document.getElementById('over-2-issues');
+    const status = document.getElementById('issues-updated-status');
+    if (buttonWithManyIssues && status) {
+      buttonWithManyIssues.role = '';
+      status.hidden = false;
+    }
+  }, 1000);
+}
 
 document.getElementById('add-two')?.addEventListener('click', () => {
   const container = document.getElementById('many-elements');

--- a/packages/devapp/src/toggle-accented.ts
+++ b/packages/devapp/src/toggle-accented.ts
@@ -34,9 +34,9 @@ if (searchParams.has('callback-invalid')) {
   options.callback = searchParams.get('output-invalid') as any;
 }
 
-if (searchParams.has('duration') && !searchParams.has('callback')) {
-  options.callback = ({scanDuration}) => {
-    console.log('Scan duration:', scanDuration);
+if (searchParams.has('performance') && !searchParams.has('callback')) {
+  options.callback = ({performance}) => {
+    console.log('Performance:', performance);
   };
 }
 


### PR DESCRIPTION
We need this update to be able to test the effect of the upcoming update that will fix layout thrashing issues.

It was necessary to add a `fullscreenchange` listener here.
Turns out, the `resize` listener doesn't fire on a fullscreen change in Playwright's version of Webkit. The test was only working before because of the change that was happening on a timeout, which we now disabled.