### PR TITLE
Make multiple color and size tweaks

### DIFF
--- a/.changeset/clever-weeks-matter.md
+++ b/.changeset/clever-weeks-matter.md
@@ -1,0 +1,5 @@
+---
+"accented": patch
+---
+
+Update appearance

--- a/packages/accented/src/dom-updater.ts
+++ b/packages/accented/src/dom-updater.ts
@@ -72,8 +72,9 @@ export default function createDomUpdater(name: string, intersectionObserver?: In
     @layer ${name} {
       :root {
         /* Ensure that the primary / secondary color combination meets WCAG 1.4.3 Contrast (Minimum) */
-        --${name}-primary-color: #d73a4a;
-        --${name}-secondary-color: white;
+        /* OKLCH stuff: https://oklch.com/ */
+        --${name}-primary-color: oklch(0.5 0.3 0);
+        --${name}-secondary-color: oklch(0.98 0 0);
         --${name}-outline-width: 2px;
         --${name}-outline-style: solid;
       }

--- a/packages/accented/src/elements/accented-dialog.ts
+++ b/packages/accented/src/elements/accented-dialog.ts
@@ -56,14 +56,50 @@ export default () => {
     :host {
       all: initial !important;
 
-      --light-color: white;
-      --dark-color: black;
-      --focus-color: #0078d4; /* Contrasts with both white and black. */
+      /* OKLCH stuff: https://oklch.com/ */
+      --light-color: oklch(0.98 0 0);
+      --dark-color: oklch(0.22 0 0);
 
-      --impact-minor-color: lightgray;
-      --impact-moderate-color: gold;
-      --impact-serious-color: #ff9e00;
-      --impact-critical-color: #f883ec;
+      --background-color: light-dark(var(--light-color), var(--dark-color));
+      --text-color: light-dark(var(--dark-color), var(--light-color));
+
+      --lightness-light: 0.80;
+      --lightness-dark: 0.45;
+
+      --blue-hue: 230;
+      --gold-hue: 90;
+      --red-hue: 0;
+
+      /* Contrasts with background. */
+      --focus-chroma: 0.25;
+      --focus-hue: var(--blue-hue);
+      --focus-color: light-dark(
+        oklch(var(--lightness-dark) var(--focus-chroma) var(--blue-hue)),
+        oklch(var(--lightness-light) var(--focus-chroma) var(--blue-hue))
+      );
+
+      --impact-chroma: 0.16;
+
+      --impact-moderate-hue: var(--blue-hue);
+      --impact-serious-hue: var(--gold-hue);
+      --impact-critical-hue: var(--red-hue);
+
+      --impact-minor-color: light-dark(
+        oklch(var(--lightness-light) 0 0),
+        oklch(var(--lightness-dark) 0 0)
+      );
+      --impact-moderate-color: light-dark(
+        oklch(var(--lightness-light) var(--impact-chroma) var(--impact-moderate-hue)),
+        oklch(var(--lightness-dark) var(--impact-chroma) var(--impact-moderate-hue))
+      );
+      --impact-serious-color: light-dark(
+        oklch(var(--lightness-light) var(--impact-chroma) var(--impact-serious-hue)),
+        oklch(var(--lightness-dark) var(--impact-chroma) var(--impact-serious-hue))
+      );
+      --impact-critical-color: light-dark(
+        oklch(var(--lightness-light) var(--impact-chroma) var(--impact-critical-hue)),
+        oklch(var(--lightness-dark) var(--impact-chroma) var(--impact-critical-hue))
+      );
 
       --base-size: max(1rem, 16px);
 
@@ -118,12 +154,15 @@ export default () => {
       overflow-wrap: break-word;
       font-family: system-ui;
       line-height: 1.5;
-      background-color: var(--light-color);
-      color: var(--dark-color);
+      text-wrap: pretty;
+      background-color: var(--background-color);
+      color: var(--text-color);
       border: 2px solid currentColor;
       padding: var(--space-l);
       inline-size: min(90ch, calc(100% - var(--space-s)* 2));
       max-block-size: calc(100% - var(--space-s) * 2);
+
+      color-scheme: light dark;
     }
 
     #button-container {
@@ -131,8 +170,8 @@ export default () => {
     }
 
     #close {
-      background-color: var(--light-color);
-      color: var(--dark-color);
+      background-color: var(--background-color);
+      color: var(--text-color);
       border: 2px solid currentColor;
       padding-inline: var(--space-2xs);
       aspect-ratio: 1 / 1;
@@ -169,7 +208,7 @@ export default () => {
       }
 
       a {
-        font-weight: bold;
+        font-weight: 500;
       }
     }
 

--- a/packages/accented/src/elements/accented-trigger.ts
+++ b/packages/accented/src/elements/accented-trigger.ts
@@ -25,6 +25,7 @@ export default (name: string) => {
   template.innerHTML = `
     <style>
       :host {
+        --ratio: 1.2;
         --base-size: max(1rem, 16px);
         position: fixed !important;
         inset-inline-start: anchor(self-start) !important;
@@ -44,18 +45,27 @@ export default (name: string) => {
         pointer-events: auto;
 
         position: absolute;
-        inset-inline-end: 0;
+        inset-block-start: 4px;
+        inset-inline-end: 4px;
 
         box-sizing: border-box;
-        font-size: var(--base-size);
+        font-size: calc(var(--ratio) * var(--ratio) * var(--base-size));
         inline-size: calc(2 * var(--base-size));
         block-size: calc(2 * var(--base-size));
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
 
         /* Make it look better in forced-colors mode. */
         border: 2px solid transparent;
 
         background-color: var(--${name}-primary-color);
         color: var(--${name}-secondary-color);
+
+        padding: 0;
+
+        border-radius: calc(0.25 * var(--base-size));
 
         outline-offset: -4px;
         outline-color: currentColor;
@@ -71,7 +81,7 @@ export default (name: string) => {
         }
       }
     </style>
-    <button id="trigger" lang="en">⚠</button>
+    <button id="trigger" lang="en">!</button>
   `;
 
   return class extends HTMLElement implements AccentedTrigger {

--- a/packages/devapp/playwright.config.ts
+++ b/packages/devapp/playwright.config.ts
@@ -44,14 +44,32 @@ export default defineConfig({
     },
 
     {
+      name: 'chromium-dark',
+      testMatch: /with-colors/,
+      use: { ...devices['Desktop Chrome'], colorScheme: 'dark' },
+    },
+
+    {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'firefox-dark',
+      testMatch: /with-colors/,
+      use: { ...devices['Desktop Firefox'], colorScheme: 'dark' },
     },
 
     {
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
     },
+
+    {
+      name: 'webkit-dark',
+      testMatch: /with-colors/,
+      use: { ...devices['Desktop Safari'], colorScheme: 'dark' },
+    }
 
     /* Test against mobile viewports. */
     // {

--- a/packages/devapp/src/index.html
+++ b/packages/devapp/src/index.html
@@ -33,7 +33,7 @@
 
       <section>
         <h2>An element with issues of various impacts</h2>
-        <button class="test-button" id="various-impacts" aria-checked="true" role="banner" style="color: lightgray;">Click me</button>
+        <button class="test-button" id="various-impacts" aria-checked="true" role="banner" lang="blah" style="background-color: lightgray; color: black;">Click me</button>
       </section>
 
       <section>

--- a/packages/devapp/src/style.css
+++ b/packages/devapp/src/style.css
@@ -1,5 +1,7 @@
 :root {
   --green-accented-primary-color: green;
+
+  color-scheme: light dark;
 }
 
 :target {

--- a/packages/devapp/test/helpers/element.ts
+++ b/packages/devapp/test/helpers/element.ts
@@ -10,7 +10,7 @@ export async function expectElementToHaveOutline (element: Locator) {
       computedStyle.getPropertyValue('outline-offset')
     ];
   });
-  await expect(outlineColor).toBe('rgb(215, 58, 74)');
+  await expect(outlineColor).toBe('oklch(0.5 0.3 0)');
   await expect(outlineWidth).toBe('2px');
   await expect(outlineOffset).toBe('-2px');
 }

--- a/packages/devapp/test/helpers/env.ts
+++ b/packages/devapp/test/helpers/env.ts
@@ -1,0 +1,8 @@
+import type { Page } from '@playwright/test';
+
+export async function isDarkMode(page: Page) {
+  return await page.evaluate(() => {
+    const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    return darkModeMediaQuery.matches;
+  });
+}

--- a/packages/devapp/test/helpers/trigger.ts
+++ b/packages/devapp/test/helpers/trigger.ts
@@ -27,6 +27,14 @@ export async function expectElementAndTriggerToBeAligned(element: Locator, trigg
   const direction = await element.evaluate(el => window.getComputedStyle(el).direction);
   const side = direction === 'ltr' ? 'right' : 'left';
   const trigger = await getTrigger(triggerContainer);
+
+  // For ease of testing, make the trigger button flush with the element's inline end and block start
+  // (usually top right).
+  await trigger.evaluate(el => {
+    el.style.setProperty('inset-inline-end', '0');
+    el.style.setProperty('inset-block-start', '0');
+  });
+
   const triggerRect = await getBoundingClientRect(trigger);
 
   // We check for approximate equality because some browsers may not line the elements up precisely.

--- a/packages/devapp/test/with-colors.spec.ts
+++ b/packages/devapp/test/with-colors.spec.ts
@@ -1,0 +1,73 @@
+import { test } from './fixtures/test';
+import { expect } from '@playwright/test';
+import { openAccentedDialog } from './helpers/dialog';
+import { isDarkMode } from './helpers/env';
+import { expectElementToHaveOutline } from './helpers/element';
+import { expectElementAndTriggerToBeAligned, getTriggerContainer } from './helpers/trigger';
+
+const accentedDataAttr = 'data-accented';
+const accentedSelector = `[${accentedDataAttr}]`;
+
+test.describe('Accented', () => {
+  test.describe('rendering', () => {
+    test('outlines with certain properties are added to elements', async ({ page }) => {
+      await page.goto('/');
+      const buttonWithIssue = await page.getByRole('button').and(page.locator(accentedSelector)).first();
+      await expectElementToHaveOutline(buttonWithIssue);
+    });
+  });
+
+  test.describe('issue dialogs', () => {
+    test('issues are sorted by impact and have specific background colors', async ({ page }) => {
+      await page.goto('/');
+      const dialog = await openAccentedDialog(page, '#various-impacts');
+      const impactElements = await dialog.getByText(/User impact:/);
+      const impacts = await impactElements.evaluateAll(elements =>
+        elements.map(element => element.textContent?.match(/User impact: (\w+)$/)?.[1]));
+      await expect(impacts).toEqual(['critical', 'critical', 'serious', 'moderate', 'minor']);
+
+      const colorMap = (await isDarkMode(page)) ? {
+        critical: 'oklch(0.45 0.16 0)',
+        serious: 'oklch(0.45 0.16 90)',
+        moderate: 'oklch(0.45 0.16 230)',
+        minor: 'oklch(0.45 0 0)'
+      } : {
+        critical: 'oklch(0.8 0.16 0)',
+        serious: 'oklch(0.8 0.16 90)',
+        moderate: 'oklch(0.8 0.16 230)',
+        minor: 'oklch(0.8 0 0)'
+      }
+
+      const backgroundColors = await impactElements.evaluateAll(elements =>
+        elements.map(element => window.getComputedStyle(element).backgroundColor));
+      await expect(backgroundColors).toEqual([
+        colorMap.critical, colorMap.critical, colorMap.serious, colorMap.moderate, colorMap.minor
+      ]);
+    });
+  });
+
+  test.describe('web platform support', () => {
+    test.describe('shadow DOM', () => {
+      test('an element in shadow DOM has a trigger that is aligned with the element, and an outline', async ({ page }) => {
+        await page.goto('/');
+        const elementWithIssue = await page.locator(`#button-in-shadow-dom${accentedSelector}`);
+        await elementWithIssue.scrollIntoViewIfNeeded();
+        await page.waitForTimeout(200);
+        const triggerContainer = await getTriggerContainer(page, elementWithIssue);
+        await expectElementAndTriggerToBeAligned(elementWithIssue, triggerContainer);
+        await expectElementToHaveOutline(elementWithIssue);
+      });
+
+      test('when an element is moved to a different shadow root, it gets a trigger that is aligned with the element', async ({ page }) => {
+        await page.goto('/');
+        (await page.getByRole('button', { name: 'Move button between shadow roots' })).click();
+        await page.waitForTimeout(1200);
+        const elementWithIssue = await page.locator(`#button-in-shadow-dom${accentedSelector}`);
+        await elementWithIssue.scrollIntoViewIfNeeded();
+        const triggerContainer = await getTriggerContainer(page, elementWithIssue);
+        await expectElementAndTriggerToBeAligned(elementWithIssue, triggerContainer);
+        await expectElementToHaveOutline(elementWithIssue);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Also, implement a dark mode. Resolves #130

Before:
<img width="266" alt="Three buttons with Accented triggers, each trigger is flush with the button edges and has a triangle character on it" src="https://github.com/user-attachments/assets/7d57d3b9-7fc4-4ffb-bfbd-ea435c4919ea" />

<img width="640" alt="Three issues in a dialog, user impacts have pink, gold, and yellow colors" src="https://github.com/user-attachments/assets/4de2018f-960d-4c7b-83ed-94ca4adbdc6f" />

After:
<img width="266" alt="Three buttons with Accented triggers, triggers are no more flush with the button edges, the character on the triggers is now an exclamation mark, and the color is slightly more pink" src="https://github.com/user-attachments/assets/eb5782ba-0a60-44f3-9109-39abded7c74e" />

<img width="635" alt="Three issues in a dialog, user impacts have updated colors: pink, yellow, and light blue; the background color is now off-white" src="https://github.com/user-attachments/assets/cc279803-778a-46f6-8dff-45faca3e5ea0" />

Dark mode (dialog):
<img width="637" alt="Three issues in a dialog, with light text and dark background" src="https://github.com/user-attachments/assets/e241214b-a468-4412-b622-4776bfc41a36" />

