### PR TITLE
Move axe test to with-colors

### DIFF
--- a/packages/devapp/test/main.spec.ts
+++ b/packages/devapp/test/main.spec.ts
@@ -5,8 +5,6 @@ import type { Locator, Page } from '@playwright/test';
 import { expectElementAndTriggerToBeAligned, getTriggerContainer, getTrigger } from './helpers/trigger';
 import { openAccentedDialog } from './helpers/dialog';
 
-import axe from 'axe-core';
-
 const accentedDataAttr = 'data-accented';
 const accentedSelector = `[${accentedDataAttr}]`;
 const accentedTriggerElementName = 'accented-trigger';
@@ -535,13 +533,6 @@ test.describe('Accented', () => {
       const updatedIssueDescriptionCount = await dialog.locator('#issues > li').count();
       expect(updatedIssueDescriptionCount).toBeLessThan(initialIssueDescriptionCount);
       await expect(dialog).toContainText('role=""');
-    });
-
-    test('the dialog itself doesn’t have accessibility issues identifiable by axe-core', async ({ page }) => {
-      await page.goto('/');
-      const dialog = await openAccentedDialog(page, '#various-impacts');
-      const violations = await dialog.evaluate(async (dialogElement) => (await axe.run(dialogElement)).violations);
-      expect(violations).toHaveLength(0);
     });
 
     test('dialog can be dismissed by clicking the mouse outside the dialog', async ({ page }) => {

--- a/packages/devapp/test/with-colors.spec.ts
+++ b/packages/devapp/test/with-colors.spec.ts
@@ -1,3 +1,4 @@
+import axe from 'axe-core';
 import { test } from './fixtures/test';
 import { expect } from '@playwright/test';
 import { openAccentedDialog } from './helpers/dialog';
@@ -43,6 +44,13 @@ test.describe('Accented', () => {
       await expect(backgroundColors).toEqual([
         colorMap.critical, colorMap.critical, colorMap.serious, colorMap.moderate, colorMap.minor
       ]);
+    });
+
+    test('the dialog itself doesn’t have accessibility issues identifiable by axe-core', async ({ page }) => {
+      await page.goto('/');
+      const dialog = await openAccentedDialog(page, '#various-impacts');
+      const violations = await dialog.evaluate(async (dialogElement) => (await axe.run(dialogElement)).violations);
+      expect(violations).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
This ensures that we test for accessibility in dark mode too.