### PR TITLE
Use named exports everywhere

### DIFF
--- a/.changeset/smart-pigs-shine.md
+++ b/.changeset/smart-pigs-shine.md
@@ -1,0 +1,5 @@
+---
+"accented": major
+---
+
+Use named exports everywhere (including the external export)

--- a/biome.json
+++ b/biome.json
@@ -58,6 +58,16 @@
           }
         }
       }
+    },
+    {
+      "include": ["packages/*/*/**/*.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noDefaultExport": "error"
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/accented/README.md
+++ b/packages/accented/README.md
@@ -12,28 +12,28 @@ TODO: example screenshots, without Accented / with Accented.
 
 ## Basic usage
 
-* The library can be used in three ways:
-  * NPM (with a bundler)
-  * `import accented from 'https://esm.sh/accented';`.
-  * `import('https://esm.sh/accented').then(({default: accented}) => { accented(); });` (this version will work in the console, unless it violates the content security policy, which shouldn't be the case locally).
-    * For example, this works on medium.com
+- The library can be used in three ways:
+  - NPM (with a bundler)
+  - `import { accented } from 'https://esm.sh/accented';`.
+  - `import('https://esm.sh/accented').then(({accented}) => { accented(); });` (this version will work in the console, unless it violates the content security policy, which shouldn't be the case locally).
+    - For example, this works on medium.com
 
 ## API
 
 ### Exports
 
-* `accented`: the default library export. It’s the function that enables the continuous scanning and highlighting
+- `accented`: the default library export. It’s the function that enables the continuous scanning and highlighting
   on the page in whose context in was called. Example: `const disable = accented(options)`.
-  * Parameters: the only parameter is `options`. See [Options](#options).
-  * Returns: a `disable` function that takes no parameters. When called, disables the scanning and highlighting,
+  - Parameters: the only parameter is `options`. See [Options](#options).
+  - Returns: a `disable` function that takes no parameters. When called, disables the scanning and highlighting,
     and cleans up any changes that Accented has made to the page.
 
 #### Type exports
 
 The following types are exported for TypeScript consumers:
 
-* `AccentedOptions`: the `options` parameter (see [Options](#options)).
-* `DisableAccented`: the type of the function returned by `accented`.
+- `AccentedOptions`: the `options` parameter (see [Options](#options)).
+- `DisableAccented`: the type of the function returned by `accented`.
 
 ### Options
 
@@ -48,11 +48,12 @@ The `context` parameter for `axe.run()`.
 Determines what element(s) to scan for accessibility issues.
 
 Accepts a variety of shapes:
-* an element reference;
-* a selector;
-* a `NodeList`;
-* an include / exclude object;
-* and more.
+
+- an element reference;
+- a selector;
+- a `NodeList`;
+- an include / exclude object;
+- and more.
 
 See documentation: https://www.deque.com/axe/core-documentation/api-documentation/#context-parameter
 
@@ -66,8 +67,8 @@ The `options` parameter for `axe.run()`.
 
 Accented only supports two keys of the `options` object:
 
-* `rules`;
-* `runOnly`.
+- `rules`;
+- `runOnly`.
 
 Both properties are optional, and both control which accessibility rules your page is tested against.
 
@@ -94,13 +95,13 @@ Whether the list of elements with issues should be printed to the browser consol
 A function that Accented will call after every scan.
 It accepts a single `params` object with the following properties:
 
-* `elementsWithIssues`: the most up-to-date array of all elements with accessibility issues.
-* `performance`: runtime performance of the last scan. An object:
-  * `totalBlockingTime`: how long the main thread was blocked by Accented during the last scan, in milliseconds.
+- `elementsWithIssues`: the most up-to-date array of all elements with accessibility issues.
+- `performance`: runtime performance of the last scan. An object:
+  - `totalBlockingTime`: how long the main thread was blocked by Accented during the last scan, in milliseconds.
     It’s further divided into the `scan` and `domUpdate` phases.
-  * `scan`: how long the `scan` phase took, in milliseconds.
-  * `domUpdate`: how long the `domUpdate` phase took, in milliseconds.
-  * `scanContext`: nodes that got scanned. Either an array of nodes,
+  - `scan`: how long the `scan` phase took, in milliseconds.
+  - `domUpdate`: how long the `domUpdate` phase took, in milliseconds.
+  - `scanContext`: nodes that got scanned. Either an array of nodes,
     or an object with `include` and `exclude` properties (if any nodes were excluded).
 
 **Example:**
@@ -124,12 +125,12 @@ The character sequence that’s used in various elements, attributes and stylesh
 
 You shouldn’t have to use this attribute unless some of the names on your page conflict with what Accented provides by default.
 
-* The data attribute that’s added to elements with issues (default: `data-accented`).
-* The custom elements for the button and the dialog that get created for each element with issues
+- The data attribute that’s added to elements with issues (default: `data-accented`).
+- The custom elements for the button and the dialog that get created for each element with issues
   (default: `accented-trigger`, `accented-dialog`).
-* The CSS cascade layer containing page-wide Accented-specific styles (default: `accented`).
-* The prefix for some of the CSS custom properties used by Accented (default: `--accented-`).
-* The window property that’s used to prevent multiple axe-core scans from running simultaneously
+- The CSS cascade layer containing page-wide Accented-specific styles (default: `accented`).
+- The prefix for some of the CSS custom properties used by Accented (default: `--accented-`).
+- The window property that’s used to prevent multiple axe-core scans from running simultaneously
   (default: `__accented_axe_running__`).
 
 Only lowercase alphanumeric characters and dashes (-) are allowed in the name,
@@ -183,10 +184,11 @@ This may be useful if you’re expecting bursts of mutations on your page.
 TODO: Create a separate doc with info on using `:root` and CSS layers to control some aspects of styling.
 
 Documented CSS custom props:
-* `--accented-primary-color`
-* `--accented-secondary-color`
-* `--accented-outline-width`
-* `--accented-outline-style`
+
+- `--accented-primary-color`
+- `--accented-secondary-color`
+- `--accented-outline-width`
+- `--accented-outline-style`
 
 ## Miscellaneous
 
@@ -214,7 +216,8 @@ TODO: expand this section and better explain the concepts.
 **Q:** does Accented affect performance?
 
 **A:** TODO: it might (it’s inevitable because it’s on the main thread), but we’ve taken X, Y, and Z measures to make it less noticeable. You can also take A, B, and C steps yourself.
-  * Only re-running on the changed part of the page.
-  * Throttling calls and giving the ability to tweak it.
-  * Providing the ability to select which rules to run, and which elements to run them on.
-  * TODO: explore axe-core’s internals. Can I make it yield periodically?
+
+- Only re-running on the changed part of the page.
+- Throttling calls and giving the ability to tweak it.
+- Providing the ability to select which rules to run, and which elements to run them on.
+- TODO: explore axe-core’s internals. Can I make it yield periodically?

--- a/packages/accented/src/accented.test.ts
+++ b/packages/accented/src/accented.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
 import type { Mock } from 'node:test';
 
-import accented from './accented.js';
+import { accented } from './accented';
 
 suite('Accented', () => {
   test('runs without errors in NodeJS and issues a warning and a trace (it’s meant to be a no-op on the server side)', (t) => {

--- a/packages/accented/src/accented.ts
+++ b/packages/accented/src/accented.ts
@@ -1,18 +1,18 @@
-import createDomUpdater from './dom-updater.js';
-import setupFullscreenListener from './fullscreen-listener.js';
-import setupIntersectionObserver from './intersection-observer.js';
-import logAndRethrow from './log-and-rethrow.js';
-import createLogger from './logger.js';
-import registerElements from './register-elements.js';
-import setupResizeListener from './resize-listener.js';
-import createScanner from './scanner.js';
-import setupScrollListeners from './scroll-listeners.js';
+import { createDomUpdater } from './dom-updater.js';
+import { setupResizeListener as setupFullscreenListener } from './fullscreen-listener.js';
+import { setupIntersectionObserver } from './intersection-observer.js';
+import { logAndRethrow } from './log-and-rethrow.js';
+import { createLogger } from './logger.js';
+import { registerElements } from './register-elements.js';
+import { setupResizeListener } from './resize-listener.js';
+import { createScanner } from './scanner.js';
+import { setupScrollListeners } from './scroll-listeners.js';
 import { enabled, extendedElementsWithIssues } from './state.js';
 import type { AccentedOptions, DisableAccented } from './types.ts';
 import { initializeContainingBlockSupportSet } from './utils/containing-blocks.js';
-import deepMerge from './utils/deep-merge.js';
-import supportsAnchorPositioning from './utils/supports-anchor-positioning.js';
-import validateOptions from './validate-options.js';
+import { deepMerge } from './utils/deep-merge.js';
+import { supportsAnchorPositioning } from './utils/supports-anchor-positioning.js';
+import { validateOptions } from './validate-options.js';
 
 export type { AccentedOptions, DisableAccented };
 
@@ -41,7 +41,7 @@ export type { AccentedOptions, DisableAccented };
  *   }
  * });
  */
-export default function accented(options: AccentedOptions = {}): DisableAccented {
+export function accented(options: AccentedOptions = {}): DisableAccented {
   validateOptions(options);
 
   try {

--- a/packages/accented/src/dom-updater.ts
+++ b/packages/accented/src/dom-updater.ts
@@ -1,10 +1,10 @@
 import { effect } from '@preact/signals-core';
 import { extendedElementsWithIssues, rootNodes } from './state.js';
 import type { ExtendedElementWithIssues } from './types.ts';
-import areElementsWithIssuesEqual from './utils/are-elements-with-issues-equal.js';
+import { areElementsWithIssuesEqual } from './utils/are-elements-with-issues-equal.js';
 import { isDocument, isDocumentFragment, isShadowRoot } from './utils/dom-helpers.js';
-import getParent from './utils/get-parent.js';
-import supportsAnchorPositioning from './utils/supports-anchor-positioning.js';
+import { getParent } from './utils/get-parent.js';
+import { supportsAnchorPositioning } from './utils/supports-anchor-positioning.js';
 
 const shouldInsertTriggerInsideElement = (element: Element): boolean => {
   /**
@@ -30,10 +30,7 @@ const shouldInsertTriggerInsideElement = (element: Element): boolean => {
   return noParent || isTableCell || isSummary;
 };
 
-export default function createDomUpdater(
-  name: string,
-  intersectionObserver?: IntersectionObserver,
-) {
+export function createDomUpdater(name: string, intersectionObserver?: IntersectionObserver) {
   const attrName = `data-${name}`;
 
   function getAnchorNames(anchorNameValue: string) {

--- a/packages/accented/src/elements/accented-dialog.ts
+++ b/packages/accented/src/elements/accented-dialog.ts
@@ -1,9 +1,9 @@
 import type { Signal } from '@preact/signals-core';
 import { accentedUrl } from '../constants.js';
-import logAndRethrow from '../log-and-rethrow.js';
+import { logAndRethrow } from '../log-and-rethrow.js';
 import type { Issue } from '../types.ts';
-import getElementHtml from '../utils/get-element-html.js';
-import isNonEmpty from '../utils/is-non-empty.js';
+import { getElementHtml } from '../utils/get-element-html.js';
+import { isNonEmpty } from '../utils/is-non-empty.js';
 
 export interface AccentedDialog extends HTMLElement {
   issues: Signal<Array<Issue>> | undefined;
@@ -14,7 +14,7 @@ export interface AccentedDialog extends HTMLElement {
 
 // We want Accented to not throw an error in Node, and use static imports,
 // so we can't export `class extends HTMLElement` because HTMLElement is not available in Node.
-export default () => {
+export const getAccentedDialog = () => {
   const dialogTemplate = document.createElement('template');
   dialogTemplate.innerHTML = `
     <dialog dir="ltr" lang="en" aria-labelledby="title">

--- a/packages/accented/src/elements/accented-trigger.ts
+++ b/packages/accented/src/elements/accented-trigger.ts
@@ -1,8 +1,8 @@
 import { effect } from '@preact/signals-core';
 import type { Signal } from '@preact/signals-core';
-import logAndRethrow from '../log-and-rethrow.js';
+import { logAndRethrow } from '../log-and-rethrow.js';
 import type { Position } from '../types.ts';
-import supportsAnchorPositioning from '../utils/supports-anchor-positioning.js';
+import { supportsAnchorPositioning } from '../utils/supports-anchor-positioning.js';
 import type { AccentedDialog } from './accented-dialog.ts';
 
 export interface AccentedTrigger extends HTMLElement {
@@ -14,7 +14,7 @@ export interface AccentedTrigger extends HTMLElement {
 
 // We want Accented to not throw an error in Node, and use static imports,
 // so we can't export `class extends HTMLElement` because HTMLElement is not available in Node.
-export default (name: string) => {
+export const getAccentedTrigger = (name: string) => {
   const template = document.createElement('template');
 
   // I initially tried creating a CSSStyelSheet object with styles instead of having a <style> element in the template,

--- a/packages/accented/src/fullscreen-listener.ts
+++ b/packages/accented/src/fullscreen-listener.ts
@@ -1,7 +1,7 @@
-import logAndRethrow from './log-and-rethrow.js';
-import recalculatePositions from './utils/recalculate-positions.js';
+import { logAndRethrow } from './log-and-rethrow.js';
+import { recalculatePositions } from './utils/recalculate-positions.js';
 
-export default function setupResizeListener() {
+export function setupResizeListener() {
   const abortController = new AbortController();
   window.addEventListener(
     'fullscreenchange',

--- a/packages/accented/src/intersection-observer.ts
+++ b/packages/accented/src/intersection-observer.ts
@@ -1,8 +1,8 @@
-import logAndRethrow from './log-and-rethrow.js';
+import { logAndRethrow } from './log-and-rethrow.js';
 import { extendedElementsWithIssues } from './state.js';
-import getElementPosition from './utils/get-element-position.js';
+import { getElementPosition } from './utils/get-element-position.js';
 
-export default function setupIntersectionObserver() {
+export function setupIntersectionObserver() {
   const intersectionObserver = new IntersectionObserver(
     (entries) => {
       try {

--- a/packages/accented/src/log-and-rethrow.ts
+++ b/packages/accented/src/log-and-rethrow.ts
@@ -1,6 +1,6 @@
 import { issuesUrl } from './constants.js';
 
-export default function logAndRethrow(error: unknown) {
+export function logAndRethrow(error: unknown) {
   console.error(
     `Accented threw an error (see below). Try updating your browser to the latest version. If you’re still seeing the error, file an issue at ${issuesUrl}.`,
   );

--- a/packages/accented/src/logger.ts
+++ b/packages/accented/src/logger.ts
@@ -7,7 +7,7 @@ function filterPropsForOutput(elements: Array<ElementWithIssues>) {
   return elements.map(({ element, issues }) => ({ element, issues }));
 }
 
-export default function createLogger() {
+export function createLogger() {
   let firstRun = true;
 
   return effect(() => {

--- a/packages/accented/src/register-elements.ts
+++ b/packages/accented/src/register-elements.ts
@@ -1,7 +1,7 @@
-import getAccentedDialog from './elements/accented-dialog.js';
-import getAccentedTrigger from './elements/accented-trigger.js';
+import { getAccentedDialog } from './elements/accented-dialog.js';
+import { getAccentedTrigger } from './elements/accented-trigger.js';
 
-export default function registerElements(name: string): void {
+export function registerElements(name: string): void {
   const elements = [
     {
       elementName: `${name}-trigger`,

--- a/packages/accented/src/resize-listener.ts
+++ b/packages/accented/src/resize-listener.ts
@@ -1,7 +1,7 @@
-import logAndRethrow from './log-and-rethrow.js';
-import recalculatePositions from './utils/recalculate-positions.js';
+import { logAndRethrow } from './log-and-rethrow.js';
+import { recalculatePositions } from './utils/recalculate-positions.js';
 
-export default function setupResizeListener() {
+export function setupResizeListener() {
   const abortController = new AbortController();
   window.addEventListener(
     'resize',

--- a/packages/accented/src/scanner.ts
+++ b/packages/accented/src/scanner.ts
@@ -1,17 +1,17 @@
 import axe from 'axe-core';
 import { getAccentedElementNames, issuesUrl } from './constants.js';
-import logAndRethrow from './log-and-rethrow.js';
+import { logAndRethrow } from './log-and-rethrow.js';
 import { elementsWithIssues, enabled, extendedElementsWithIssues } from './state.js';
-import TaskQueue from './task-queue.js';
+import { TaskQueue } from './task-queue.js';
 import type { AxeOptions, Callback, Context, Throttle } from './types.ts';
-import getScanContext from './utils/get-scan-context.js';
-import recalculatePositions from './utils/recalculate-positions.js';
-import recalculateScrollableAncestors from './utils/recalculate-scrollable-ancestors.js';
-import createShadowDOMAwareMutationObserver from './utils/shadow-dom-aware-mutation-observer.js';
-import supportsAnchorPositioning from './utils/supports-anchor-positioning.js';
-import updateElementsWithIssues from './utils/update-elements-with-issues.js';
+import { getScanContext } from './utils/get-scan-context.js';
+import { recalculatePositions } from './utils/recalculate-positions.js';
+import { recalculateScrollableAncestors } from './utils/recalculate-scrollable-ancestors.js';
+import { createShadowDOMAwareMutationObserver } from './utils/shadow-dom-aware-mutation-observer.js';
+import { supportsAnchorPositioning } from './utils/supports-anchor-positioning.js';
+import { updateElementsWithIssues } from './utils/update-elements-with-issues.js';
 
-export default function createScanner(
+export function createScanner(
   name: string,
   context: Context,
   axeOptions: AxeOptions,

--- a/packages/accented/src/scroll-listeners.ts
+++ b/packages/accented/src/scroll-listeners.ts
@@ -1,9 +1,9 @@
 import { effect } from '@preact/signals-core';
-import logAndRethrow from './log-and-rethrow.js';
+import { logAndRethrow } from './log-and-rethrow.js';
 import { scrollableAncestors } from './state.js';
-import recalculatePositions from './utils/recalculate-positions.js';
+import { recalculatePositions } from './utils/recalculate-positions.js';
 
-export default function setupScrollListeners() {
+export function setupScrollListeners() {
   const documentAbortController = new AbortController();
   document.addEventListener(
     'scroll',

--- a/packages/accented/src/task-queue.test.ts
+++ b/packages/accented/src/task-queue.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { mock, suite, test } from 'node:test';
 
-import TaskQueue from './task-queue.js';
+import { TaskQueue } from './task-queue';
 
 const wait = (duration: number) => new Promise((resolve) => setTimeout(resolve, duration));
 

--- a/packages/accented/src/task-queue.ts
+++ b/packages/accented/src/task-queue.ts
@@ -2,7 +2,7 @@ import type { Throttle } from './types.ts';
 
 type TaskCallback<T> = (items: Array<T>) => void;
 
-export default class TaskQueue<T> {
+export class TaskQueue<T> {
   #throttle: Throttle;
   #asyncCallback: TaskCallback<T> | null = null;
 

--- a/packages/accented/src/utils/are-elements-with-issues-equal.ts
+++ b/packages/accented/src/utils/are-elements-with-issues-equal.ts
@@ -1,6 +1,6 @@
 import type { BaseElementWithIssues } from '../types.ts';
 
-export default function areElementsWithIssuesEqual(
+export function areElementsWithIssuesEqual(
   elementWithIssues1: BaseElementWithIssues,
   elementWithIssues2: BaseElementWithIssues,
 ) {

--- a/packages/accented/src/utils/are-issue-sets-equal.test.ts
+++ b/packages/accented/src/utils/are-issue-sets-equal.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
 import type { Issue } from '../types';
-import areIssueSetsEqual from './are-issue-sets-equal.js';
+import { areIssueSetsEqual } from './are-issue-sets-equal';
 
 const issue1: Issue = {
   id: 'id1',

--- a/packages/accented/src/utils/are-issue-sets-equal.ts
+++ b/packages/accented/src/utils/are-issue-sets-equal.ts
@@ -2,7 +2,7 @@ import type { Issue } from '../types.ts';
 
 const issueProps: Array<keyof Issue> = ['id', 'title', 'description', 'url', 'impact'];
 
-export default function areIssueSetsEqual(issues1: Array<Issue>, issues2: Array<Issue>) {
+export function areIssueSetsEqual(issues1: Array<Issue>, issues2: Array<Issue>) {
   return (
     issues1.length === issues2.length &&
     issues1.every((issue1) =>

--- a/packages/accented/src/utils/contains.test.ts
+++ b/packages/accented/src/utils/contains.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
 import { JSDOM } from 'jsdom';
-import contains from './contains';
+import { contains } from './contains';
 
 suite('contains', () => {
   test('an element contains itself', () => {

--- a/packages/accented/src/utils/contains.ts
+++ b/packages/accented/src/utils/contains.ts
@@ -1,6 +1,6 @@
 import { isDocumentFragment, isShadowRoot } from './dom-helpers.js';
 
-export default function contains(ancestor: Node, descendant: Node): boolean {
+export function contains(ancestor: Node, descendant: Node): boolean {
   if (ancestor.contains(descendant)) {
     return true;
   }

--- a/packages/accented/src/utils/deep-merge.test.ts
+++ b/packages/accented/src/utils/deep-merge.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
 
-import deepMerge from './deep-merge';
+import { deepMerge } from './deep-merge';
 
 suite('deepMerge', () => {
   test('merges two objects with overlapping keys', () => {

--- a/packages/accented/src/utils/deep-merge.ts
+++ b/packages/accented/src/utils/deep-merge.ts
@@ -4,7 +4,7 @@ type AnyObject = Record<string, any>;
 const isObject = (obj: unknown): obj is AnyObject =>
   typeof obj === 'object' && obj !== null && !Array.isArray(obj);
 
-export default function deepMerge(target: AnyObject, source: AnyObject): AnyObject {
+export function deepMerge(target: AnyObject, source: AnyObject): AnyObject {
   const output = { ...target };
   for (const key of Object.keys(source)) {
     if (isObject(source[key])) {

--- a/packages/accented/src/utils/ensure-non-empty.ts
+++ b/packages/accented/src/utils/ensure-non-empty.ts
@@ -1,4 +1,4 @@
-export default function ensureNonEmpty<T>(arr: T[]): [T, ...T[]] {
+export function ensureNonEmpty<T>(arr: T[]): [T, ...T[]] {
   if (arr.length === 0) {
     throw new Error('Array must not be empty');
   }

--- a/packages/accented/src/utils/get-element-html.ts
+++ b/packages/accented/src/utils/get-element-html.ts
@@ -1,4 +1,4 @@
-export default function getElementHtml(element: Element) {
+export function getElementHtml(element: Element) {
   const outerHtml = element.outerHTML;
   const innerHtml = element.innerHTML;
   if (!innerHtml) {

--- a/packages/accented/src/utils/get-element-position.ts
+++ b/packages/accented/src/utils/get-element-position.ts
@@ -1,7 +1,7 @@
 import type { Position } from '../types.ts';
 import { createsContainingBlock } from './containing-blocks.js';
 import { isHtmlElement } from './dom-helpers.js';
-import getParent from './get-parent.js';
+import { getParent } from './get-parent.js';
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Containing_block#identifying_the_containing_block
 function isContainingBlock(element: Element, win: Window): boolean {
@@ -52,7 +52,7 @@ function getNonInitialContainingBlock(element: Element, win: Window): Element | 
  * * The element itself, or one of the element's ancestors has a scale or rotate transform.
  * * The browser doesn't support anchor positioning.
  */
-export default function getElementPosition(element: Element, win: Window): Position {
+export function getElementPosition(element: Element, win: Window): Position {
   const nonInitialContainingBlock = getNonInitialContainingBlock(element, win);
   // If an element has a containing block as an ancestor,
   // and that containing block is not the <html> element (the initial containing block),

--- a/packages/accented/src/utils/get-parent.ts
+++ b/packages/accented/src/utils/get-parent.ts
@@ -1,6 +1,6 @@
 import { isDocumentFragment, isShadowRoot } from './dom-helpers.js';
 
-export default function getParent(element: Element): Element | null {
+export function getParent(element: Element): Element | null {
   if (element.parentElement) {
     return element.parentElement;
   }

--- a/packages/accented/src/utils/get-scan-context.test.ts
+++ b/packages/accented/src/utils/get-scan-context.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
 import { JSDOM } from 'jsdom';
-import getScanContext from './get-scan-context';
+import { getScanContext } from './get-scan-context';
 
 suite('getScanContext', () => {
   test('when context doesn’t overlap with nodes, the result is empty', () => {

--- a/packages/accented/src/utils/get-scan-context.ts
+++ b/packages/accented/src/utils/get-scan-context.ts
@@ -1,10 +1,10 @@
 import type { Context, ScanContext } from '../types.ts';
-import contains from './contains.js';
+import { contains } from './contains.js';
 import { deduplicateNodes } from './deduplicate-nodes.js';
-import isNodeInScanContext from './is-node-in-scan-context.js';
-import normalizeContext from './normalize-context.js';
+import { isNodeInScanContext } from './is-node-in-scan-context.js';
+import { normalizeContext } from './normalize-context.js';
 
-export default function getScanContext(nodes: Array<Node>, context: Context): ScanContext {
+export function getScanContext(nodes: Array<Node>, context: Context): ScanContext {
   const { include: contextInclude, exclude: contextExclude } = normalizeContext(context);
 
   // Filter only nodes that are included by context (see isNodeInContext above).

--- a/packages/accented/src/utils/get-scrollable-ancestors.ts
+++ b/packages/accented/src/utils/get-scrollable-ancestors.ts
@@ -1,8 +1,8 @@
-import getParent from './get-parent.js';
+import { getParent } from './get-parent.js';
 
 const scrollableOverflowValues = new Set(['auto', 'scroll', 'hidden']);
 
-export default function getScrollableAncestors(element: Element, win: Window) {
+export function getScrollableAncestors(element: Element, win: Window) {
   let currentElement: Element | null = element;
   const scrollableAncestors = new Set<Element>();
   while (true) {

--- a/packages/accented/src/utils/is-node-in-scan-context.test.ts
+++ b/packages/accented/src/utils/is-node-in-scan-context.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
 import { JSDOM } from 'jsdom';
-import isNodeInScanContext from './is-node-in-scan-context';
+import { isNodeInScanContext } from './is-node-in-scan-context';
 
 suite('isNodeInScanContext', () => {
   test('doesn’t include an element if scan context is empty', () => {

--- a/packages/accented/src/utils/is-node-in-scan-context.ts
+++ b/packages/accented/src/utils/is-node-in-scan-context.ts
@@ -1,8 +1,8 @@
 /* Adapted from https://github.com/dequelabs/axe-core/blob/fd6239bfc97ebc904044f93f68d7e49137f744ad/lib/core/utils/is-node-in-context.js */
 
 import type { ScanContext } from '../types.ts';
-import contains from './contains.js';
-import ensureNonEmpty from './ensure-non-empty.js';
+import { contains } from './contains.js';
+import { ensureNonEmpty } from './ensure-non-empty.js';
 
 function getDeepest(nodes: [Node, ...Node[]]): Node {
   let deepest = nodes[0];
@@ -14,10 +14,7 @@ function getDeepest(nodes: [Node, ...Node[]]): Node {
   return deepest;
 }
 
-export default function isNodeInScanContext(
-  node: Node,
-  { include, exclude }: ScanContext,
-): boolean {
+export function isNodeInScanContext(node: Node, { include, exclude }: ScanContext): boolean {
   const filteredInclude = include.filter((includeNode) => contains(includeNode, node));
   if (filteredInclude.length === 0) {
     return false;

--- a/packages/accented/src/utils/is-non-empty.ts
+++ b/packages/accented/src/utils/is-non-empty.ts
@@ -1,3 +1,3 @@
-export default function isNonEmpty<T>(arr: T[]): arr is [T, ...T[]] {
+export function isNonEmpty<T>(arr: T[]): arr is [T, ...T[]] {
   return arr.length > 0;
 }

--- a/packages/accented/src/utils/normalize-context.test.ts
+++ b/packages/accented/src/utils/normalize-context.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
 import { JSDOM } from 'jsdom';
-import normalizeContext from './normalize-context';
+import { normalizeContext } from './normalize-context';
 
 suite('normalizeContext', () => {
   test('when document is passed, only document is returned in include', () => {

--- a/packages/accented/src/utils/normalize-context.ts
+++ b/packages/accented/src/utils/normalize-context.ts
@@ -1,7 +1,7 @@
 import type { Context, ContextProp, ScanContext, Selector } from '../types.ts';
 import { deduplicateNodes } from './deduplicate-nodes.js';
 import { isNode, isNodeList } from './dom-helpers.js';
-import isNonEmpty from './is-non-empty.js';
+import { isNonEmpty } from './is-non-empty.js';
 
 function recursiveSelectAll(
   selectors: [string, ...string[]],
@@ -44,7 +44,7 @@ function contextPropToNodes(contextProp: ContextProp): Array<Node> {
   return deduplicateNodes(nodes);
 }
 
-export default function normalizeContext(context: Context): ScanContext {
+export function normalizeContext(context: Context): ScanContext {
   let contextInclude: Array<Node> = [];
   let contextExclude: Array<Node> = [];
   if (typeof context === 'object' && ('include' in context || 'exclude' in context)) {

--- a/packages/accented/src/utils/recalculate-positions.ts
+++ b/packages/accented/src/utils/recalculate-positions.ts
@@ -1,11 +1,11 @@
 import { batch } from '@preact/signals-core';
-import logAndRethrow from '../log-and-rethrow.js';
+import { logAndRethrow } from '../log-and-rethrow.js';
 import { extendedElementsWithIssues } from '../state.js';
-import getElementPosition from './get-element-position.js';
+import { getElementPosition } from './get-element-position.js';
 
 let frameRequested = false;
 
-export default function recalculatePositions() {
+export function recalculatePositions() {
   if (frameRequested) {
     return;
   }

--- a/packages/accented/src/utils/recalculate-scrollable-ancestors.ts
+++ b/packages/accented/src/utils/recalculate-scrollable-ancestors.ts
@@ -1,8 +1,8 @@
 import { batch } from '@preact/signals-core';
 import { extendedElementsWithIssues } from '../state.js';
-import getScrollableAncestors from './get-scrollable-ancestors.js';
+import { getScrollableAncestors } from './get-scrollable-ancestors.js';
 
-export default function recalculateScrollableAncestors() {
+export function recalculateScrollableAncestors() {
   batch(() => {
     for (const { element, scrollableAncestors } of extendedElementsWithIssues.value) {
       if (element.isConnected) {

--- a/packages/accented/src/utils/shadow-dom-aware-mutation-observer.ts
+++ b/packages/accented/src/utils/shadow-dom-aware-mutation-observer.ts
@@ -1,10 +1,7 @@
 import { getAccentedElementNames } from '../constants.js';
 import { isDocument, isDocumentFragment, isElement } from './dom-helpers.js';
 
-export default function createShadowDOMAwareMutationObserver(
-  name: string,
-  callback: MutationCallback,
-) {
+export function createShadowDOMAwareMutationObserver(name: string, callback: MutationCallback) {
   class ShadowDOMAwareMutationObserver extends MutationObserver {
     #shadowRoots = new Set();
 

--- a/packages/accented/src/utils/supports-anchor-positioning.ts
+++ b/packages/accented/src/utils/supports-anchor-positioning.ts
@@ -2,6 +2,6 @@ type WindowWithCSS = Window & {
   CSS: typeof CSS;
 };
 
-export default function supportsAnchorPositioning(win: WindowWithCSS) {
+export function supportsAnchorPositioning(win: WindowWithCSS) {
   return win.CSS.supports('anchor-name: --foo') && win.CSS.supports('position-anchor: --foo');
 }

--- a/packages/accented/src/utils/transform-violations.test.ts
+++ b/packages/accented/src/utils/transform-violations.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
-import transformViolations from './transform-violations';
+import { transformViolations } from './transform-violations';
 
 import type { AxeResults } from 'axe-core';
 type Violation = AxeResults['violations'][number];

--- a/packages/accented/src/utils/transform-violations.ts
+++ b/packages/accented/src/utils/transform-violations.ts
@@ -25,10 +25,7 @@ function impactCompare(a: ImpactValue, b: ImpactValue) {
   return impactOrder.indexOf(a) - impactOrder.indexOf(b);
 }
 
-export default function transformViolations(
-  violations: typeof AxeResults.violations,
-  name: string,
-) {
+export function transformViolations(violations: typeof AxeResults.violations, name: string) {
   const elementsWithIssues: Array<ElementWithIssues> = [];
 
   for (const violation of violations) {

--- a/packages/accented/src/utils/update-elements-with-issues.test.ts
+++ b/packages/accented/src/utils/update-elements-with-issues.test.ts
@@ -3,7 +3,7 @@ import { suite, test } from 'node:test';
 import type { Signal } from '@preact/signals-core';
 import { signal } from '@preact/signals-core';
 import type { ExtendedElementWithIssues, Issue } from '../types';
-import updateElementsWithIssues from './update-elements-with-issues';
+import { updateElementsWithIssues } from './update-elements-with-issues';
 
 import type { AxeResults, ImpactValue } from 'axe-core';
 import type { AccentedTrigger } from '../elements/accented-trigger';

--- a/packages/accented/src/utils/update-elements-with-issues.ts
+++ b/packages/accented/src/utils/update-elements-with-issues.ts
@@ -4,15 +4,15 @@ import type { AxeResults } from 'axe-core';
 import type { AccentedDialog } from '../elements/accented-dialog.ts';
 import type { AccentedTrigger } from '../elements/accented-trigger.ts';
 import type { ExtendedElementWithIssues, ScanContext } from '../types.ts';
-import areElementsWithIssuesEqual from './are-elements-with-issues-equal.js';
-import areIssueSetsEqual from './are-issue-sets-equal.js';
+import { areElementsWithIssuesEqual } from './are-elements-with-issues-equal.js';
+import { areIssueSetsEqual } from './are-issue-sets-equal.js';
 import { isSvgElement } from './dom-helpers.js';
-import getElementPosition from './get-element-position.js';
-import getParent from './get-parent.js';
-import getScrollableAncestors from './get-scrollable-ancestors.js';
-import isNodeInScanContext from './is-node-in-scan-context.js';
-import supportsAnchorPositioning from './supports-anchor-positioning.js';
-import transformViolations from './transform-violations.js';
+import { getElementPosition } from './get-element-position.js';
+import { getParent } from './get-parent.js';
+import { getScrollableAncestors } from './get-scrollable-ancestors.js';
+import { isNodeInScanContext } from './is-node-in-scan-context.js';
+import { supportsAnchorPositioning } from './supports-anchor-positioning.js';
+import { transformViolations } from './transform-violations.js';
 
 function shouldSkipRender(element: Element): boolean {
   // Skip rendering if the element is inside an SVG:
@@ -32,7 +32,7 @@ function shouldSkipRender(element: Element): boolean {
 
 let count = 0;
 
-export default function updateElementsWithIssues({
+export function updateElementsWithIssues({
   extendedElementsWithIssues,
   scanContext,
   violations,

--- a/packages/accented/src/validate-options.ts
+++ b/packages/accented/src/validate-options.ts
@@ -117,7 +117,7 @@ function validateContext(context: Context) {
 // lowercase alphanumeric names that possibly contain dashes that start with a letter.
 const nameRegex = /^[a-z]([a-z0-9]|-)+$/;
 
-export default function validateOptions(options: AccentedOptions) {
+export function validateOptions(options: AccentedOptions) {
   if (typeof options !== 'object' || options === null) {
     throw new TypeError(
       `Accented: invalid argument. The options parameter must be an object if provided. It’s currently set to ${options}.`,

--- a/packages/devapp/src/main.ts
+++ b/packages/devapp/src/main.ts
@@ -1,4 +1,4 @@
-import toggleAccented from './toggle-accented';
+import { toggleAccented } from './toggle-accented';
 
 const searchParams = new URLSearchParams(location.search);
 

--- a/packages/devapp/src/toggle-accented.ts
+++ b/packages/devapp/src/toggle-accented.ts
@@ -1,4 +1,4 @@
-import accented from 'accented';
+import { accented } from 'accented';
 import type { AccentedOptions, DisableAccented } from 'accented';
 import type { RuleObject } from 'axe-core';
 
@@ -6,7 +6,7 @@ const searchParams = new URLSearchParams(location.search);
 
 let stopAccented: DisableAccented | null = null;
 
-function toggleAccented(opts: AccentedOptions = {}) {
+function toggleAccentedInner(opts: AccentedOptions = {}) {
   if (stopAccented) {
     stopAccented();
     stopAccented = null;
@@ -107,13 +107,13 @@ if (searchParams.has('axe-context-selector')) {
 }
 
 if (!searchParams.has('disable')) {
-  toggleAccented(options);
+  toggleAccentedInner(options);
 
   if (searchParams.has('quick-toggle')) {
     queueMicrotask(() => {
-      toggleAccented(options);
+      toggleAccentedInner(options);
       queueMicrotask(() => {
-        toggleAccented(options);
+        toggleAccentedInner(options);
       });
     });
   }
@@ -129,6 +129,6 @@ if (searchParams.has('small-caps')) {
   document.adoptedStyleSheets = [...document.adoptedStyleSheets, stylesheet];
 }
 
-export default () => {
-  toggleAccented(options);
+export const toggleAccented = () => {
+  toggleAccentedInner(options);
 };


### PR DESCRIPTION
See https://biomejs.dev/linter/rules/no-default-export/

In addition to the above reasons, this is also to reduce mental overhead for authors: we should never have to decide what type of export to use, we always use named exports, and that's it:
https://gomakethings.com/no-default-exports/


