### PR TITLE
Fix trigger visibility when overflowing overflow: visible containers

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["accented-devapp"]
+  "ignore": ["accented-devapp", "common", "website"]
 }

--- a/.changeset/wise-flies-hope.md
+++ b/.changeset/wise-flies-hope.md
@@ -1,0 +1,5 @@
+---
+"accented": patch
+---
+
+Fix trigger visibility in Chrome when overflowing overflow: visible containers

--- a/packages/accented/src/accented.ts
+++ b/packages/accented/src/accented.ts
@@ -96,13 +96,11 @@ export function accented(options: AccentedOptions = {}): DisableAccented {
     registerElements(name);
 
     const { disconnect: cleanupIntersectionObserver, intersectionObserver } =
-      supportsAnchorPositioning(window) ? {} : setupIntersectionObserver();
+      setupIntersectionObserver();
     const cleanupScanner = createScanner(name, context, axeOptions, throttle, callback);
     const cleanupDomUpdater = createDomUpdater(name, intersectionObserver);
     const cleanupLogger = output.console ? createLogger() : () => {};
-    const cleanupScrollListeners = supportsAnchorPositioning(window)
-      ? () => {}
-      : setupScrollListeners();
+    const cleanupScrollListeners = setupScrollListeners();
     const cleanupResizeListener = supportsAnchorPositioning(window)
       ? () => {}
       : setupResizeListener();

--- a/packages/accented/src/elements/accented-trigger.ts
+++ b/packages/accented/src/elements/accented-trigger.ts
@@ -33,8 +33,6 @@ export const getAccentedTrigger = (name: string) => {
         inset-block-start: anchor(self-start) !important;
         inset-block-end: anchor(self-end) !important;
 
-        position-visibility: anchors-visible !important;
-
         /* Revert potential effects of white-space: pre; set on a trigger's ancestor. */
         white-space: normal !important;
 
@@ -193,15 +191,14 @@ export const getAccentedTrigger = (name: string) => {
                 this.style.setProperty('height', `${position.height}px`, 'important');
               }
             });
-
-            this.#disposeOfVisibilityEffect = effect(() => {
-              this.style.setProperty(
-                'visibility',
-                this.visible?.value ? 'visible' : 'hidden',
-                'important',
-              );
-            });
           }
+          this.#disposeOfVisibilityEffect = effect(() => {
+            this.style.setProperty(
+              'visibility',
+              this.visible?.value ? 'visible' : 'hidden',
+              'important',
+            );
+          });
         }
       } catch (error) {
         logAndRethrow(error);

--- a/packages/accented/src/intersection-observer.ts
+++ b/packages/accented/src/intersection-observer.ts
@@ -1,6 +1,7 @@
 import { logAndRethrow } from './log-and-rethrow.js';
 import { extendedElementsWithIssues } from './state.js';
 import { getElementPosition } from './utils/get-element-position.js';
+import { supportsAnchorPositioning } from './utils/supports-anchor-positioning.js';
 
 export function setupIntersectionObserver() {
   const intersectionObserver = new IntersectionObserver(
@@ -11,8 +12,13 @@ export function setupIntersectionObserver() {
             (el) => el.element === entry.target,
           );
           if (extendedElementWithIssues) {
+            // We initially treated setting visibility in the intersection observer
+            // as a fallback option for browsers that don't support `position-visibility`,
+            // but then we realized that this `position-visibility` actually works
+            // in an unexpected way when the container has `overflow: visible`.
+            // So now we always set visibility in the intersection observer.
             extendedElementWithIssues.visible.value = entry.isIntersecting;
-            if (entry.isIntersecting) {
+            if (entry.isIntersecting && !supportsAnchorPositioning(window)) {
               extendedElementWithIssues.position.value = getElementPosition(entry.target, window);
             }
           }

--- a/packages/devapp/test/main.spec.ts
+++ b/packages/devapp/test/main.spec.ts
@@ -264,15 +264,7 @@ test.describe('Accented', () => {
       const button2Trigger = await getTrigger(button2TriggerContainer);
 
       async function expectToBeHiddenOutsideScrollableRegion(element: Locator) {
-        if (await supportsAnchorPositioning(page)) {
-          // I'm not sure how to really test the button for visibility here.
-          // It's hidden using position-visibility: anchors-visible,
-          // but that doesn't seem to affect how Playwright calculates visibility.
-          // Hopefully in a future version of Playwright this is addressed.
-          await expect(element).toBeVisible();
-        } else {
-          await expect(element).not.toBeVisible();
-        }
+        await expect(element).not.toBeVisible();
       }
 
       await scrollableRegion.scrollIntoViewIfNeeded();


### PR DESCRIPTION
We initially treated setting visibility in the intersection observer as a fallback option for browsers that don't support `position-visibility`, but then we realized that this `position-visibility` actually works in an unexpected way when the container has `overflow: visible`.
So now we always set visibility in the intersection observer, and if we want to revert to using `position-visibility`, we need to ensure that overflowing a container with `overflow: visible` doesn't hide the triggers.
It's easy to test manually (for example, by setting `height: 100vh` on the `body`), however writing an automated test for it proved to be tricky. With `position-visibility: anchors-visible`, I wasn't able to test whether the element was actually visible or not. For example, the new `Element.checkVisibility()` method returns `true` even if the element is hidden, which may be a bug in the API.