### PR TITLE
Upgrade biome and promote useImportType to error level

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -14,9 +14,7 @@
     "indentWidth": 2,
     "lineWidth": 100
   },
-  "organizeImports": {
-    "enabled": true
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
@@ -28,7 +26,8 @@
         "noUnusedVariables": "error"
       },
       "style": {
-        "noNonNullAssertion": "off"
+        "noNonNullAssertion": "off",
+        "useImportType": "error"
       },
       "suspicious": {
         "noExplicitAny": "off"
@@ -42,8 +41,7 @@
   },
   "overrides": [
     {
-      "include": ["packages/accented/src/**/*.ts"],
-      "ignore": ["packages/accented/src/**/*.test.ts"],
+      "includes": ["**/packages/accented/src/**/*.ts", "!**/packages/accented/src/**/*.test.ts"],
       "linter": {
         "rules": {
           "correctness": {
@@ -59,7 +57,7 @@
       }
     },
     {
-      "include": ["packages/*/*/**/*.ts"],
+      "includes": ["**/packages/**/*/*/**/*.ts"],
       "linter": {
         "rules": {
           "style": {
@@ -69,7 +67,7 @@
       }
     },
     {
-      "include": ["**/*.astro"],
+      "includes": ["**/*.astro"],
       "linter": {
         "rules": {
           "correctness": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "test:e2e": "pnpm --filter accented-devapp test",
     "changeset-version": "pnpm changeset version && pnpm biome format --write"
   },
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "devDependencies": {
-    "@biomejs/biome": "1.9.4",
+    "@biomejs/biome": "2.1.2",
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.28.1",
     "@types/node": "^24.0.0",

--- a/packages/accented/package.json
+++ b/packages/accented/package.json
@@ -4,7 +4,11 @@
   "description": "A frontend library for continuous accessibility testing and issue highlighting",
   "type": "module",
   "main": "dist/accented.js",
-  "files": ["dist", "src", "NOTICE"],
+  "files": [
+    "dist",
+    "src",
+    "NOTICE"
+  ],
   "scripts": {
     "prepare": "cp ../../NOTICE ./NOTICE",
     "build": "pnpm copyCommon && tsc",
@@ -20,7 +24,13 @@
     "type": "git",
     "url": "git+https://github.com/pomerantsev/accented.git"
   },
-  "keywords": ["accessibility", "a11y", "a11y-testing", "axe", "axe-core"],
+  "keywords": [
+    "accessibility",
+    "a11y",
+    "a11y-testing",
+    "axe",
+    "axe-core"
+  ],
   "author": "Pavel Pomerantsev",
   "license": "MIT",
   "bugs": {

--- a/packages/accented/src/accented.test.ts
+++ b/packages/accented/src/accented.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { suite, test } from 'node:test';
 import type { Mock } from 'node:test';
+import { suite, test } from 'node:test';
 
 import { accented } from './accented';
 

--- a/packages/accented/src/elements/accented-trigger.ts
+++ b/packages/accented/src/elements/accented-trigger.ts
@@ -1,5 +1,5 @@
-import { effect } from '@preact/signals-core';
 import type { Signal } from '@preact/signals-core';
+import { effect } from '@preact/signals-core';
 import { fontSystemSans } from '../common/tokens.js';
 import { logAndRethrow } from '../log-and-rethrow.js';
 import type { Position } from '../types.ts';

--- a/packages/accented/src/utils/transform-violations.test.ts
+++ b/packages/accented/src/utils/transform-violations.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
+import type { AxeResults } from 'axe-core';
 import { transformViolations } from './transform-violations';
 
-import type { AxeResults } from 'axe-core';
 type Violation = AxeResults['violations'][number];
 type Node = Violation['nodes'][number];
 

--- a/packages/accented/src/utils/update-elements-with-issues.test.ts
+++ b/packages/accented/src/utils/update-elements-with-issues.test.ts
@@ -2,11 +2,11 @@ import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
 import type { Signal } from '@preact/signals-core';
 import { signal } from '@preact/signals-core';
+import type { AxeResults, ImpactValue } from 'axe-core';
+import type { AccentedTrigger } from '../elements/accented-trigger';
 import type { ExtendedElementWithIssues, Issue } from '../types';
 import { updateElementsWithIssues } from './update-elements-with-issues';
 
-import type { AxeResults, ImpactValue } from 'axe-core';
-import type { AccentedTrigger } from '../elements/accented-trigger';
 type Violation = AxeResults['violations'][number];
 type AxeNode = Violation['nodes'][number];
 

--- a/packages/devapp/src/toggle-accented.ts
+++ b/packages/devapp/src/toggle-accented.ts
@@ -1,5 +1,5 @@
-import { accented } from 'accented';
-import type { AccentedOptions, DisableAccented } from 'accented';
+import type { AccentedOptions } from 'accented';
+import { accented, type DisableAccented } from 'accented';
 import type { RuleObject } from 'axe-core';
 
 const searchParams = new URLSearchParams(location.search);

--- a/packages/devapp/test/helpers/element.ts
+++ b/packages/devapp/test/helpers/element.ts
@@ -1,5 +1,4 @@
-import { expect } from '@playwright/test';
-import type { Locator } from '@playwright/test';
+import { expect, type Locator } from '@playwright/test';
 
 export async function expectElementToHaveOutline(element: Locator) {
   const [outlineColor, outlineWidth, outlineOffset] = await element.evaluate((el) => {

--- a/packages/devapp/test/main.spec.ts
+++ b/packages/devapp/test/main.spec.ts
@@ -1,5 +1,5 @@
-import { expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { test } from './fixtures/test';
 
 import { openAccentedDialog } from './helpers/dialog';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: 1.9.4
-        version: 1.9.4
+        specifier: 2.1.2
+        version: 2.1.2
       '@changesets/changelog-github':
         specifier: ^0.5.1
         version: 0.5.1
@@ -158,55 +158,55 @@ packages:
     resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@2.1.2':
+    resolution: {integrity: sha512-yq8ZZuKuBVDgAS76LWCfFKHSYIAgqkxVB3mGVVpOe2vSkUTs7xG46zXZeNPRNVjiJuw0SZ3+J2rXiYx0RUpfGg==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@2.1.2':
+    resolution: {integrity: sha512-leFAks64PEIjc7MY/cLjE8u5OcfBKkcDB0szxsWUB4aDfemBep1WVKt0qrEyqZBOW8LPHzrFMyDl3FhuuA0E7g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@2.1.2':
+    resolution: {integrity: sha512-Nmmv7wRX5Nj7lGmz0FjnWdflJg4zii8Ivruas6PBKzw5SJX/q+Zh2RfnO+bBnuKLXpj8kiI2x2X12otpH6a32A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@2.1.2':
+    resolution: {integrity: sha512-qgHvafhjH7Oca114FdOScmIKf1DlXT1LqbOrrbR30kQDLFPEOpBG0uzx6MhmsrmhGiCFCr2obDamu+czk+X0HQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+  '@biomejs/cli-linux-arm64@2.1.2':
+    resolution: {integrity: sha512-NWNy2Diocav61HZiv2enTQykbPP/KrA/baS7JsLSojC7Xxh2nl9IczuvE5UID7+ksRy2e7yH7klm/WkA72G1dw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@2.1.2':
+    resolution: {integrity: sha512-xlB3mU14ZUa3wzLtXfmk2IMOGL+S0aHFhSix/nssWS/2XlD27q+S6f0dlQ8WOCbYoXcuz8BCM7rCn2lxdTrlQA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+  '@biomejs/cli-linux-x64@2.1.2':
+    resolution: {integrity: sha512-Km/UYeVowygTjpX6sGBzlizjakLoMQkxWbruVZSNE6osuSI63i4uCeIL+6q2AJlD3dxoiBJX70dn1enjQnQqwA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@2.1.2':
+    resolution: {integrity: sha512-G8KWZli5ASOXA3yUQgx+M4pZRv3ND16h77UsdunUL17uYpcL/UC7RkWTdkfvMQvogVsAuz5JUcBDjgZHXxlKoA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+  '@biomejs/cli-win32-x64@2.1.2':
+    resolution: {integrity: sha512-9zajnk59PMpjBkty3bK2IrjUsUHvqe9HWwyAWQBjGLE7MIBjbX2vwv1XPEhmO2RRuGoTkVx3WCanHrjAytICLA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -5831,39 +5831,39 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@2.1.2':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': 2.1.2
+      '@biomejs/cli-darwin-x64': 2.1.2
+      '@biomejs/cli-linux-arm64': 2.1.2
+      '@biomejs/cli-linux-arm64-musl': 2.1.2
+      '@biomejs/cli-linux-x64': 2.1.2
+      '@biomejs/cli-linux-x64-musl': 2.1.2
+      '@biomejs/cli-win32-arm64': 2.1.2
+      '@biomejs/cli-win32-x64': 2.1.2
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@2.1.2':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-darwin-x64@2.1.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@2.1.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-linux-arm64@2.1.2':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@2.1.2':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@biomejs/cli-linux-x64@2.1.2':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@2.1.2':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@biomejs/cli-win32-x64@2.1.2':
     optional: true
 
   '@bugsnag/browser@8.2.0':


### PR DESCRIPTION
Fixes #195 

Migrate Biome 1.9.4 -> 2.1.2.

This was supposed to promote all recommended rules to `error` level, but due to some issue, it didn't: https://github.com/biomejs/biome/issues/6372#issuecomment-2981958402

That's probably okay though, not sure what rules I relied on.

This change actually does nothing to #195, it was just implicitly an error in v1, and with v2, I made it an error explicitly (it's now a warning by default in Biome).