### PR TITLE
Only keep / for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/packages/*"
+    directory: "/"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
-  - "packages/*"
+  - packages/*
+
+onlyBuiltDependencies:
+  - esbuild
+  - netlify-cli
+  - sharp


### PR DESCRIPTION
Remove `"packages/*"` from directories. Looks like we don't need that, and those PRs are incorrect anyway (the `pnpm-lock` file doesn't get updated).