### PR TITLE
Fix scheduled Lychee runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist
 
 # Local Netlify folder
 .netlify
+
+# Lychee
+.lycheecache

--- a/packages/website/scripts/checkLinks.mjs
+++ b/packages/website/scripts/checkLinks.mjs
@@ -83,15 +83,21 @@ async function runToCompletion(process, args) {
   });
 }
 
+const commonLycheeArgs = [
+  '--exclude',
+  '/sitemap-index\.xml$',
+  '--verbose',
+  '--cache',
+  '--max-retries',
+  '3',
+  '--retry-wait-time',
+  '5',
+];
+
 async function runLychee(urls) {
   try {
     let exitCode;
-    exitCode = await runToCompletion('lychee', [
-      '--exclude',
-      '/sitemap-index\.xml$',
-      ...urls,
-      '-v',
-    ]);
+    exitCode = await runToCompletion('lychee', [...commonLycheeArgs, ...urls]);
 
     if (exitCode === 0) {
       /**
@@ -101,13 +107,11 @@ async function runLychee(urls) {
        * I couldn't find a way to avoid this, but I think it's fine.
        */
       exitCode = await runToCompletion('lychee', [
-        '--exclude',
-        '/sitemap-index\.xml$',
+        ...commonLycheeArgs,
         '--exclude',
         '^https',
         '--include-fragments',
         ...urls,
-        '-v',
       ]);
     }
     await cleanup();


### PR DESCRIPTION
Every scheduled Lychee run failed in the past three days:
* https://github.com/pomerantsev/accented/actions/runs/16534071792/job/46765290314
* https://github.com/pomerantsev/accented/actions/runs/16545442790/job/46792378491
* https://github.com/pomerantsev/accented/actions/runs/16557253984/job/46820561787

This change might fix the issue by introducing caching and retries.