### PR TITLE
Fix Copy button positioning in Safari and Firefox

### DIFF
--- a/packages/website/src/components/copyCode.ts
+++ b/packages/website/src/components/copyCode.ts
@@ -3,6 +3,7 @@ const defaultButtonText = 'Copy';
 class CopyCodeElement extends HTMLElement {
   connectedCallback() {
     this.style.position = 'relative';
+    this.style.display = 'block';
     // Create the button element
     const button = document.createElement('button');
     button.className = 'copy';


### PR DESCRIPTION
It was only visible in Chrome.