### PR TITLE
Fix RSS icon in Safari

### DIFF
--- a/packages/website/src/components/icons/RSS.astro
+++ b/packages/website/src/components/icons/RSS.astro
@@ -1,5 +1,6 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
+  style="inline-size: 1em;"
   viewBox="0 0 448 512"
 >
   <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->


### PR DESCRIPTION
The icon was fully invisible in Safari.