### PR TITLE
Fix axe-core trademark usage

### DIFF
--- a/.changeset/bitter-comics-begin.md
+++ b/.changeset/bitter-comics-begin.md
@@ -1,0 +1,5 @@
+---
+"accented": patch
+---
+
+Remove an improper use of the axe-core trademark from the Accented dialog

--- a/packages/accented/src/elements/accented-dialog.ts
+++ b/packages/accented/src/elements/accented-dialog.ts
@@ -41,8 +41,6 @@ export const getAccentedDialog = () => {
         <p>
           Powered by
           <a href="${accentedUrl}" target="_blank" aria-description="Opens in new tab">Accented</a>
-          and
-          <a href="https://github.com/dequelabs/axe-core" target="_blank" aria-description="Opens in new tab">axe-core</a>.
         </p>
       </section>
     </dialog>

--- a/packages/website/src/blog/2025-07-16-introducing-accented.mdx
+++ b/packages/website/src/blog/2025-07-16-introducing-accented.mdx
@@ -22,7 +22,7 @@ if (process.env.NODE_ENV === 'development') {
 
 That’s all the setup you need to get real-time accessibility auditing
 of the page that’s rendered in your browser,
-using [axe-core](https://github.com/dequelabs/axe-core),
+using [axe-core®](https://github.com/dequelabs/axe-core),
 the most popular accessibility testing engine.
 
 Each element with at least one accessibility issue gets highlighted.

--- a/packages/website/src/layouts/MainLayout.astro
+++ b/packages/website/src/layouts/MainLayout.astro
@@ -71,8 +71,9 @@ const isDev = import.meta.env.DEV;
     <main id="main-content">
       <slot />
     </main>
-    <footer>
+    <footer class="flow">
       <p>Made by <a href="https://www.pavelpomerantsev.com">Pavel Pomerantsev</a>.</p>
+      <p>axe-core® is a trademark of Deque Systems, Inc. in the US and other countries.</p>
     </footer>
     <script>
       import '~/components/copyCode';

--- a/packages/website/src/pages/index.mdx
+++ b/packages/website/src/pages/index.mdx
@@ -37,7 +37,7 @@ An example of an application without Accented / with Accented:
 
 ## Features
 
-- **Based on [axe-core](https://github.com/dequelabs/axe-core),**
+- **Based on [axe-core®](https://github.com/dequelabs/axe-core),**
   the world’s most popular accessibility testing engine.
 - **Instant and continuous feedback:** it highlights issues in the current state of the page you’re working on.
 - **Initialized with just a few lines of code.**


### PR DESCRIPTION
Here's the Deque trademark usage guidelines: https://www.deque.com/legal/trademarks/
To comply, I decided to:
* remove the "axe-core" name from the Accented dialog;
* add the “axe-core® is a trademark of Deque Systems, Inc. in the US and other countries.” sentence to website footer;
* add the ® character to a couple of prominent uses of axe-core on the website.