### PR TITLE
Tweaks

### DIFF
--- a/.changeset/slow-drinks-arrive.md
+++ b/.changeset/slow-drinks-arrive.md
@@ -1,0 +1,5 @@
+---
+"accented": patch
+---
+
+Fix some edge cases in ShadowDOMAwareMutationObserver

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,11 @@
         "noUnusedFunctionParameters": "error",
         "noUnusedImports": "error",
         "noUnusedPrivateClassMembers": "error",
-        "noUnusedVariables": "error"
+        "noUnusedVariables": "error",
+        "useParseIntRadix": "error"
+      },
+      "nursery": {
+        "noShadow": "error"
       },
       "style": {
         "noNonNullAssertion": "off",

--- a/packages/accented/src/accented.ts
+++ b/packages/accented/src/accented.ts
@@ -100,10 +100,8 @@ export function accented(options: AccentedOptions = {}): DisableAccented {
     const cleanupDomUpdater = output.page ? createDomUpdater(name, intersectionObserver) : () => {};
     const cleanupLogger = output.console ? createLogger() : () => {};
     const cleanupScrollListeners = output.page ? setupScrollListeners() : () => {};
-    const cleanupResizeListener = supportsAnchorPositioning(window)
-      ? () => {}
-      : setupResizeListener();
-    const cleanupFullscreenListener = supportsAnchorPositioning(window)
+    const cleanupResizeListener = supportsAnchorPositioning() ? () => {} : setupResizeListener();
+    const cleanupFullscreenListener = supportsAnchorPositioning()
       ? () => {}
       : setupFullscreenListener();
 

--- a/packages/accented/src/dom-updater.ts
+++ b/packages/accented/src/dom-updater.ts
@@ -67,7 +67,7 @@ export function createDomUpdater(name: string, intersectionObserver?: Intersecti
         continue;
       }
       elementWithIssues.element.setAttribute(attrName, elementWithIssues.id.toString());
-      if (supportsAnchorPositioning(window)) {
+      if (supportsAnchorPositioning()) {
         setAnchorName(elementWithIssues);
       }
 
@@ -88,7 +88,7 @@ export function createDomUpdater(name: string, intersectionObserver?: Intersecti
         continue;
       }
       elementWithIssues.element.removeAttribute(attrName);
-      if (supportsAnchorPositioning(window)) {
+      if (supportsAnchorPositioning()) {
         removeAnchorName(elementWithIssues);
       }
       elementWithIssues.trigger.remove();

--- a/packages/accented/src/dom-updater.ts
+++ b/packages/accented/src/dom-updater.ts
@@ -61,8 +61,8 @@ export function createDomUpdater(name: string, intersectionObserver?: Intersecti
     }
   }
 
-  function setIssues(extendedElementsWithIssues: Array<ExtendedElementWithIssues>) {
-    for (const elementWithIssues of extendedElementsWithIssues) {
+  function setIssues(elementsWithIssues: Array<ExtendedElementWithIssues>) {
+    for (const elementWithIssues of elementsWithIssues) {
       if (elementWithIssues.skipRender) {
         continue;
       }
@@ -82,8 +82,8 @@ export function createDomUpdater(name: string, intersectionObserver?: Intersecti
     }
   }
 
-  function removeIssues(extendedElementsWithIssues: Array<ExtendedElementWithIssues>) {
-    for (const elementWithIssues of extendedElementsWithIssues) {
+  function removeIssues(elementsWithIssues: Array<ExtendedElementWithIssues>) {
+    for (const elementWithIssues of elementsWithIssues) {
       if (elementWithIssues.skipRender) {
         continue;
       }

--- a/packages/accented/src/elements/accented-dialog.ts
+++ b/packages/accented/src/elements/accented-dialog.ts
@@ -140,7 +140,7 @@ export const getAccentedDialog = () => {
       color: var(--text-color);
       border: 2px solid currentColor;
       padding: var(--space-l);
-      inline-size: min(90ch, calc(100% - var(--space-s)* 2));
+      inline-size: min(90ch, calc(100% - var(--space-s) * 2));
       max-block-size: calc(100% - var(--space-s) * 2);
 
       color-scheme: light dark;

--- a/packages/accented/src/elements/accented-trigger.ts
+++ b/packages/accented/src/elements/accented-trigger.ts
@@ -30,7 +30,7 @@ export const getAccentedTrigger = (name: string) => {
         --base-size: max(1rem, 16px);
         position: fixed !important;
         ${
-          supportsAnchorPositioning(window)
+          supportsAnchorPositioning()
             ? `
           inset-inline-start: anchor(self-start) !important;
           inset-inline-end: anchor(self-end) !important;
@@ -191,7 +191,7 @@ export const getAccentedTrigger = (name: string) => {
             { signal: this.#abortController.signal },
           );
 
-          if (!supportsAnchorPositioning(window)) {
+          if (!supportsAnchorPositioning()) {
             this.#disposeOfPositionEffect = effect(() => {
               if (this.position && trigger) {
                 const position = this.position.value;

--- a/packages/accented/src/intersection-observer.ts
+++ b/packages/accented/src/intersection-observer.ts
@@ -18,7 +18,7 @@ export function setupIntersectionObserver() {
             // in an unexpected way when the container has `overflow: visible`.
             // So now we always set visibility in the intersection observer.
             extendedElementWithIssues.visible.value = entry.isIntersecting;
-            if (entry.isIntersecting && !supportsAnchorPositioning(window)) {
+            if (entry.isIntersecting && !supportsAnchorPositioning()) {
               extendedElementWithIssues.position.value = getElementPosition(entry.target, window);
             }
           }

--- a/packages/accented/src/intersection-observer.ts
+++ b/packages/accented/src/intersection-observer.ts
@@ -19,7 +19,7 @@ export function setupIntersectionObserver() {
             // So now we always set visibility in the intersection observer.
             extendedElementWithIssues.visible.value = entry.isIntersecting;
             if (entry.isIntersecting && !supportsAnchorPositioning()) {
-              extendedElementWithIssues.position.value = getElementPosition(entry.target, window);
+              extendedElementWithIssues.position.value = getElementPosition(entry.target);
             }
           }
         }

--- a/packages/accented/src/logger.ts
+++ b/packages/accented/src/logger.ts
@@ -53,8 +53,8 @@ type IssueType = {
 
 type GroupedByIssueType = Record<string, IssueType>;
 
-const getIssueTypeGroups = (elementsWithIssues: Array<ElementWithIssues>) => {
-  const groupedByIssueType = elementsWithIssues.reduce((acc, { element, issues }) => {
+const getIssueTypeGroups = (elsWithIssues: Array<ElementWithIssues>) => {
+  const groupedByIssueType = elsWithIssues.reduce((acc, { element, issues }) => {
     for (const issue of issues) {
       if (!acc[issue.id]) {
         acc[issue.id] = {
@@ -80,11 +80,11 @@ const getIssueTypeGroups = (elementsWithIssues: Array<ElementWithIssues>) => {
   return sorted;
 };
 
-function logIssuesByElement(elementsWithIssues: Array<ElementWithIssues>) {
+function logIssuesByElement(elsWithIssues: Array<ElementWithIssues>) {
   // Elements with more severe issues (or with a higher number of issues of the same severity)
   // will appear higher in the output.
   // This way, issues with a higher severity will be prioritized.
-  const sortedElementsWithIssues = elementsWithIssues.toSorted((a, b) => {
+  const sortedElementsWithIssues = elsWithIssues.toSorted((a, b) => {
     const impacts = orderedImpacts.toReversed();
     const impactWithDifferentIssueCount = impacts.find((impact) => {
       const aCount = a.issues.filter((issue) => issue.impact === impact).length;
@@ -172,12 +172,12 @@ function logIssuesByType(issueTypeGroups: Array<IssueType>) {
 }
 
 function logNewIssues(
-  elementsWithIssues: Array<ElementWithIssues>,
+  elsWithIssues: Array<ElementWithIssues>,
   previousElementsWithIssues: Array<ElementWithIssues>,
 ) {
   // The elements with accessibility issues that didn't have any associated issues
   // or that weren't in the DOM at the time of last scan.
-  const addedElements = elementsWithIssues.filter((elementWithIssues) => {
+  const addedElements = elsWithIssues.filter((elementWithIssues) => {
     return !previousElementsWithIssues.some((previousElementWithIssues) =>
       areElementsWithIssuesEqual(previousElementWithIssues, elementWithIssues),
     );
@@ -185,7 +185,7 @@ function logNewIssues(
 
   // The elements that now have more issues than at the time of last scan,
   // with just the new issues (previously existing issues are filtered out).
-  const existingElementsWithNewIssues = elementsWithIssues.reduce<Array<ElementWithIssues>>(
+  const existingElementsWithNewIssues = elsWithIssues.reduce<Array<ElementWithIssues>>(
     (acc, elementWithIssues) => {
       let foundElementWithIssues: ElementWithIssues | null = null;
       for (const previousElementWithIssues of previousElementsWithIssues) {
@@ -232,17 +232,17 @@ function logNewIssues(
 }
 
 function logIssues(
-  elementsWithIssues: Array<ElementWithIssues>,
+  elsWithIssues: Array<ElementWithIssues>,
   previousElementsWithIssues: Array<ElementWithIssues>,
 ) {
-  const elementCount = elementsWithIssues.length;
+  const elementCount = elsWithIssues.length;
 
   if (elementCount === 0) {
     console.log(`No accessibility issues (Accented, ${accentedUrl}).`);
     return;
   }
 
-  const issueCount = elementsWithIssues.reduce((acc, { issues }) => acc + issues.length, 0);
+  const issueCount = elsWithIssues.reduce((acc, { issues }) => acc + issues.length, 0);
   console.group(
     `%c${issueCount} accessibility issue${issueCount === 1 ? '' : 's'} in ${elementCount} element${elementCount === 1 ? '' : 's'} (Accented, ${accentedUrl}):\n`,
     defaultStyle,
@@ -251,16 +251,16 @@ function logIssues(
   if (issueCount <= MAX_ISSUES_BEFORE_OUTPUT_COLLAPSE) {
     // Don't collapse issues if there are not too many (this hopefully helps user avoid unnecessary clicks in the console).
     // Output by element (no specific reason for this choice, just a preference).
-    logIssuesByElement(elementsWithIssues);
+    logIssuesByElement(elsWithIssues);
   } else {
     // When there are many issues, outputting them all would probably make the console too noisy,
     // so we collapse them.
     // Moreover, we output all issues twice, by element and by issue type, to give users more choice.
-    console.groupCollapsed(`%cAll by element (${elementsWithIssues.length})`, defaultStyle);
-    logIssuesByElement(elementsWithIssues);
+    console.groupCollapsed(`%cAll by element (${elsWithIssues.length})`, defaultStyle);
+    logIssuesByElement(elsWithIssues);
     console.groupEnd();
 
-    const issueTypeGroups = getIssueTypeGroups(elementsWithIssues);
+    const issueTypeGroups = getIssueTypeGroups(elsWithIssues);
     console.groupCollapsed(`%cAll by issue type (${issueTypeGroups.length})`, defaultStyle);
     logIssuesByType(issueTypeGroups);
     console.groupEnd();
@@ -269,7 +269,7 @@ function logIssues(
   if (previousElementsWithIssues.length > 0) {
     // Log new issues separately, to make it easier for the user to know what issues
     // were introduced recently.
-    logNewIssues(elementsWithIssues, previousElementsWithIssues);
+    logNewIssues(elsWithIssues, previousElementsWithIssues);
   }
 
   console.groupEnd();

--- a/packages/accented/src/scanner.ts
+++ b/packages/accented/src/scanner.ts
@@ -143,7 +143,7 @@ export function createScanner(
         return !(onlyAccentedElementsAddedOrRemoved || accentedElementChanged);
       });
 
-      if (listWithoutAccentedElements.length !== 0 && !supportsAnchorPositioning(window)) {
+      if (listWithoutAccentedElements.length !== 0 && !supportsAnchorPositioning()) {
         // Something has changed in the DOM, so we need to realign all triggers with respective elements.
         recalculatePositions();
 

--- a/packages/accented/src/scanner.ts
+++ b/packages/accented/src/scanner.ts
@@ -96,7 +96,6 @@ export function createScanner(
         extendedElementsWithIssues,
         scanContext,
         violations: result.violations,
-        win: window,
         name,
       });
 

--- a/packages/accented/src/scanner.ts
+++ b/packages/accented/src/scanner.ts
@@ -159,14 +159,14 @@ export function createScanner(
       // we may miss other mutations on those same elements caused by Accented,
       // leading to extra runs of the mutation observer.
       const elementsWithAccentedAttributeChanges = listWithoutAccentedElements.reduce(
-        (nodes, mutationRecord) => {
+        (acc, mutationRecord) => {
           if (
             mutationRecord.type === 'attributes' &&
             mutationRecord.attributeName === `data-${name}`
           ) {
-            nodes.add(mutationRecord.target);
+            acc.add(mutationRecord.target);
           }
-          return nodes;
+          return acc;
         },
         new Set<Node>(),
       );

--- a/packages/accented/src/state.ts
+++ b/packages/accented/src/state.ts
@@ -14,10 +14,10 @@ export const elementsWithIssues = computed<Array<ElementWithIssues>>(() =>
   })),
 );
 
-export const rootNodes = computed<Set<Node>>(
+export const rootNodes = computed(
   () =>
     new Set(
-      (enabled.value ? [document as Node] : []).concat(
+      Array.from<Node>(enabled.value ? [document] : []).concat(
         ...extendedElementsWithIssues.value.map(
           (extendedElementWithIssues) => extendedElementWithIssues.rootNode,
         ),
@@ -26,10 +26,10 @@ export const rootNodes = computed<Set<Node>>(
 );
 
 export const scrollableAncestors = computed<Set<Element>>(() =>
-  extendedElementsWithIssues.value.reduce((scrollableAncestors, extendedElementWithIssues) => {
+  extendedElementsWithIssues.value.reduce((acc, extendedElementWithIssues) => {
     for (const scrollableAncestor of extendedElementWithIssues.scrollableAncestors.value) {
-      scrollableAncestors.add(scrollableAncestor);
+      acc.add(scrollableAncestor);
     }
-    return scrollableAncestors;
+    return acc;
   }, new Set<Element>()),
 );

--- a/packages/accented/src/utils/get-element-position.ts
+++ b/packages/accented/src/utils/get-element-position.ts
@@ -4,8 +4,8 @@ import { isHtmlElement } from './dom-helpers.js';
 import { getParent } from './get-parent.js';
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Containing_block#identifying_the_containing_block
-function isContainingBlock(element: Element, win: Window): boolean {
-  const style = win.getComputedStyle(element);
+function isContainingBlock(element: Element): boolean {
+  const style = getComputedStyle(element);
   const {
     transform,
     perspective,
@@ -33,11 +33,11 @@ function isContainingBlock(element: Element, win: Window): boolean {
   );
 }
 
-function getNonInitialContainingBlock(element: Element, win: Window): Element | null {
+function getNonInitialContainingBlock(element: Element): Element | null {
   let currentElement: Element | null = element;
   while (currentElement) {
     currentElement = getParent(currentElement);
-    if (currentElement && isContainingBlock(currentElement, win)) {
+    if (currentElement && isContainingBlock(currentElement)) {
       return currentElement;
     }
   }
@@ -52,8 +52,8 @@ function getNonInitialContainingBlock(element: Element, win: Window): Element | 
  * * The element itself, or one of the element's ancestors has a scale or rotate transform.
  * * The browser doesn't support anchor positioning.
  */
-export function getElementPosition(element: Element, win: Window): Position {
-  const nonInitialContainingBlock = getNonInitialContainingBlock(element, win);
+export function getElementPosition(element: Element): Position {
+  const nonInitialContainingBlock = getNonInitialContainingBlock(element);
   // If an element has a containing block as an ancestor,
   // and that containing block is not the <html> element (the initial containing block),
   // fixed positioning works differently.

--- a/packages/accented/src/utils/get-scrollable-ancestors.ts
+++ b/packages/accented/src/utils/get-scrollable-ancestors.ts
@@ -2,7 +2,7 @@ import { getParent } from './get-parent.js';
 
 const scrollableOverflowValues = new Set(['auto', 'scroll', 'hidden']);
 
-export function getScrollableAncestors(element: Element, win: Window) {
+export function getScrollableAncestors(element: Element) {
   let currentElement: Element | null = element;
   const scrollableAncestors = new Set<Element>();
   while (true) {
@@ -10,7 +10,7 @@ export function getScrollableAncestors(element: Element, win: Window) {
     if (!currentElement) {
       break;
     }
-    const computedStyle = win.getComputedStyle(currentElement);
+    const computedStyle = getComputedStyle(currentElement);
     if (
       scrollableOverflowValues.has(computedStyle.overflowX) ||
       scrollableOverflowValues.has(computedStyle.overflowY)

--- a/packages/accented/src/utils/recalculate-positions.ts
+++ b/packages/accented/src/utils/recalculate-positions.ts
@@ -16,7 +16,7 @@ export function recalculatePositions() {
       batch(() => {
         for (const { element, position, visible } of extendedElementsWithIssues.value) {
           if (visible.value && element.isConnected) {
-            position.value = getElementPosition(element, window);
+            position.value = getElementPosition(element);
           }
         }
       });

--- a/packages/accented/src/utils/recalculate-scrollable-ancestors.ts
+++ b/packages/accented/src/utils/recalculate-scrollable-ancestors.ts
@@ -6,7 +6,7 @@ export function recalculateScrollableAncestors() {
   batch(() => {
     for (const { element, scrollableAncestors } of extendedElementsWithIssues.value) {
       if (element.isConnected) {
-        scrollableAncestors.value = getScrollableAncestors(element, window);
+        scrollableAncestors.value = getScrollableAncestors(element);
       }
     }
   });

--- a/packages/accented/src/utils/shadow-dom-aware-mutation-observer.test.ts
+++ b/packages/accented/src/utils/shadow-dom-aware-mutation-observer.test.ts
@@ -1,0 +1,413 @@
+import assert from 'node:assert/strict';
+import { beforeEach, suite, test } from 'node:test';
+import { JSDOM } from 'jsdom';
+import { createShadowDOMAwareMutationObserver } from './shadow-dom-aware-mutation-observer';
+
+type MutationAssertion = {
+  type: string;
+  target?: Node;
+  addedNodes?: { length: number; tagName?: string };
+  removedNodes?: { length: number; tagName?: string };
+};
+
+const createTestDOM = (html = '<div id="container"></div>') => {
+  const dom = new JSDOM(html);
+  return { dom, document: dom.window.document };
+};
+
+const waitForMutation = (ms = 10) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const createElementWithShadowRoot = (document: Document, tagName = 'div') => {
+  const element = document.createElement(tagName);
+  const shadowRoot = element.attachShadow({ mode: 'open' });
+  return { element, shadowRoot };
+};
+
+const assertMutationEquals = (mutation: MutationRecord, expected: MutationAssertion) => {
+  assert.equal(mutation.type, expected.type);
+  if (expected.target) {
+    assert.equal(mutation.target, expected.target);
+  }
+  if (expected.addedNodes) {
+    assert.equal(mutation.addedNodes.length, expected.addedNodes.length);
+    if (expected.addedNodes.tagName) {
+      assert.equal((mutation.addedNodes[0] as Element)?.tagName, expected.addedNodes.tagName);
+    }
+  }
+  if (expected.removedNodes) {
+    assert.equal(mutation.removedNodes.length, expected.removedNodes.length);
+    if (expected.removedNodes.tagName) {
+      assert.equal((mutation.removedNodes[0] as Element)?.tagName, expected.removedNodes.tagName);
+    }
+  }
+};
+
+const createAsyncMutationTest = (expectedMutations: number) => {
+  let mutationCount = 0;
+  let resolveTest: () => void;
+  const testComplete = new Promise<void>((resolve) => {
+    resolveTest = resolve;
+  });
+
+  const handleMutation =
+    (callback: (mutations: MutationRecord[], count: number) => void) =>
+    (mutations: MutationRecord[]) => {
+      mutationCount++;
+      callback(mutations, mutationCount);
+
+      if (mutationCount === expectedMutations) {
+        resolveTest();
+      }
+    };
+
+  return { handleMutation, testComplete, getMutationCount: () => mutationCount };
+};
+
+suite('ShadowDOMAwareMutationObserver', () => {
+  beforeEach(() => {
+    const dom = new JSDOM();
+    global.Node = dom.window.Node;
+    global.MutationObserver = dom.window.MutationObserver;
+  });
+
+  suite('inserting elements', () => {
+    test('fires when a node is inserted in an observed node', (_t, done) => {
+      const { document } = createTestDOM();
+      const container = document.querySelector('#container')!;
+
+      const observer = createShadowDOMAwareMutationObserver('test', (mutations) => {
+        assert.equal(mutations.length, 1);
+        assertMutationEquals(mutations[0]!, {
+          type: 'childList',
+          addedNodes: { length: 1, tagName: 'DIV' },
+        });
+
+        done();
+      });
+
+      observer.observe(container, { childList: true });
+
+      const newDiv = document.createElement('div');
+      container.appendChild(newDiv);
+    });
+
+    test('fires when a node is inserted in a shadow root of an observed element', (_t, done) => {
+      const { document } = createTestDOM('<div id="container"><div id="host"></div></div>');
+      const container = document.querySelector('#container')!;
+      const host = document.querySelector('#host')!;
+
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+
+      const observer = createShadowDOMAwareMutationObserver('test', (mutations) => {
+        assert.equal(mutations.length, 1);
+        assertMutationEquals(mutations[0]!, {
+          type: 'childList',
+          addedNodes: { length: 1, tagName: 'DIV' },
+        });
+
+        done();
+      });
+
+      observer.observe(container, { childList: true });
+
+      const newDiv = document.createElement('div');
+      shadowRoot.appendChild(newDiv);
+    });
+
+    // This is an unfortunate limitation: we cannot be notified when a shadow root is created
+    // in the observed DOM. When that happens, the whole shadow root subtree will stay unobserved.
+    test('does not fire when a node is inserted in a shadow root created after observer starts', (_t, done) => {
+      const { document } = createTestDOM('<div id="container"><div id="host"></div></div>');
+      const container = document.querySelector('#container')!;
+      const host = document.querySelector('#host')!;
+
+      let callbackFired = false;
+      const observer = createShadowDOMAwareMutationObserver('test', () => {
+        callbackFired = true;
+        done(new Error('Callback should not have fired'));
+      });
+
+      observer.observe(container, { childList: true, subtree: true });
+
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+      const newDiv = document.createElement('div');
+      shadowRoot.appendChild(newDiv);
+
+      setTimeout(() => {
+        assert.equal(
+          callbackFired,
+          false,
+          'Callback should not have fired for shadow root created after observation',
+        );
+        done();
+      }, 50);
+    });
+
+    test('discovers shadow roots when descendants with shadow roots are added', async () => {
+      // This test verifies that when a wrapper element containing descendant shadow hosts
+      // is added to the DOM, the shadow roots are properly discovered and observed
+      const { document } = createTestDOM();
+      const container = document.querySelector('#container')!;
+
+      const { handleMutation, testComplete } = createAsyncMutationTest(2);
+
+      const { element: hostElement, shadowRoot } = createElementWithShadowRoot(document);
+      const wrapper = document.createElement('div');
+      wrapper.appendChild(hostElement);
+
+      const observer = createShadowDOMAwareMutationObserver(
+        'test',
+        handleMutation((mutations, count) => {
+          assert.equal(mutations.length, 1);
+
+          if (count === 1) {
+            // First mutation: wrapper with descendant that has shadow root
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: container,
+              addedNodes: { length: 1, tagName: 'DIV' },
+            });
+          } else if (count === 2) {
+            // Second mutation: element added to the shadow root that was discovered
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: shadowRoot,
+              addedNodes: { length: 1, tagName: 'SPAN' },
+            });
+          }
+        }),
+      );
+
+      observer.observe(container, { childList: true, subtree: true });
+
+      container.appendChild(wrapper);
+      await waitForMutation();
+
+      const shadowDiv = document.createElement('span');
+      shadowRoot.appendChild(shadowDiv);
+
+      await testComplete;
+    });
+
+    test('discovers shadow roots on directly added elements', async () => {
+      // This test verifies that shadow roots are discovered on elements that are
+      // added directly to the observed container (not just on descendants)
+      const { document } = createTestDOM();
+      const container = document.querySelector('#container')!;
+
+      const { handleMutation, testComplete } = createAsyncMutationTest(2);
+      const { element: hostElement, shadowRoot } = createElementWithShadowRoot(document);
+
+      const observer = createShadowDOMAwareMutationObserver(
+        'test',
+        handleMutation((mutations, count) => {
+          assert.equal(mutations.length, 1);
+
+          if (count === 1) {
+            // First mutation: element with shadow root added directly
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: container,
+              addedNodes: { length: 1, tagName: 'DIV' },
+            });
+          } else if (count === 2) {
+            // Second mutation: element added to the shadow root on the directly added element
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: shadowRoot,
+              addedNodes: { length: 1, tagName: 'SPAN' },
+            });
+          }
+        }),
+      );
+
+      observer.observe(container, { childList: true, subtree: true });
+
+      // Add element with shadow root directly to container
+      // This should now work with the bug fix (previously didn't work)
+      container.appendChild(hostElement);
+      await waitForMutation();
+
+      const shadowDiv = document.createElement('span');
+      shadowRoot.appendChild(shadowDiv);
+
+      await testComplete;
+    });
+
+    test('discovers and observes nested shadow roots (two levels deep)', async () => {
+      const { document } = createTestDOM();
+      const container = document.querySelector('#container')!;
+
+      const { handleMutation, testComplete } = createAsyncMutationTest(3);
+      const { element: outerElement, shadowRoot: outerShadowRoot } =
+        createElementWithShadowRoot(document);
+      const { element: innerElement, shadowRoot: innerShadowRoot } = createElementWithShadowRoot(
+        document,
+        'span',
+      );
+
+      const observer = createShadowDOMAwareMutationObserver(
+        'test',
+        handleMutation((mutations, count) => {
+          assert.equal(mutations.length, 1);
+
+          if (count === 1) {
+            // First mutation: outer element with shadow root added
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: container,
+              addedNodes: { length: 1, tagName: 'DIV' },
+            });
+          } else if (count === 2) {
+            // Second mutation: inner element with nested shadow root added to outer shadow root
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: outerShadowRoot,
+              addedNodes: { length: 1, tagName: 'SPAN' },
+            });
+          } else if (count === 3) {
+            // Third mutation: element added to nested (inner) shadow root
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: innerShadowRoot,
+              addedNodes: { length: 1, tagName: 'P' },
+            });
+          }
+        }),
+      );
+
+      observer.observe(container, { childList: true, subtree: true });
+
+      container.appendChild(outerElement);
+      await waitForMutation();
+
+      outerShadowRoot.appendChild(innerElement);
+      await waitForMutation();
+
+      const deepElement = document.createElement('p');
+      innerShadowRoot.appendChild(deepElement);
+
+      await testComplete;
+    });
+  });
+
+  suite('removing elements', () => {
+    // Tests for proper cleanup when elements are removed from the DOM
+    test('does not fire when elements are added to removed elements', async () => {
+      const { document } = createTestDOM();
+      const container = document.querySelector('#container')!;
+
+      const { handleMutation, testComplete } = createAsyncMutationTest(2);
+      let completionScheduled = false;
+
+      const observer = createShadowDOMAwareMutationObserver(
+        'test',
+        handleMutation((mutations, count) => {
+          assert.equal(mutations.length, 1);
+
+          if (count === 1) {
+            // First mutation: element added to container
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: container,
+              addedNodes: { length: 1, tagName: 'DIV' },
+            });
+          } else if (count === 2) {
+            // Second mutation: element removed from container
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: container,
+              removedNodes: { length: 1, tagName: 'DIV' },
+            });
+
+            // Schedule completion check to ensure no third mutation occurs
+            if (!completionScheduled) {
+              completionScheduled = true;
+            }
+          } else {
+            throw new Error(`Unexpected mutation count: ${count}`);
+          }
+        }),
+      );
+
+      observer.observe(container, { childList: true, subtree: true });
+
+      const testElement = document.createElement('div');
+      container.appendChild(testElement);
+      await waitForMutation();
+
+      container.removeChild(testElement);
+      await waitForMutation();
+
+      // Add element to the removed element (should NOT trigger mutation)
+      const childElement = document.createElement('span');
+      testElement.appendChild(childElement);
+
+      await testComplete;
+    });
+
+    test('does not fire when elements are added to shadow roots of removed hosts', async () => {
+      const { document } = createTestDOM();
+      const container = document.querySelector('#container')!;
+
+      const { handleMutation, testComplete } = createAsyncMutationTest(3);
+      const { element: shadowHost, shadowRoot } = createElementWithShadowRoot(document);
+      let completionScheduled = false;
+
+      const observer = createShadowDOMAwareMutationObserver(
+        'test',
+        handleMutation((mutations, count) => {
+          assert.equal(mutations.length, 1);
+
+          if (count === 1) {
+            // First mutation: shadow host added to container
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: container,
+              addedNodes: { length: 1, tagName: 'DIV' },
+            });
+          } else if (count === 2) {
+            // Second mutation: element added to shadow root
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: shadowRoot,
+              addedNodes: { length: 1, tagName: 'SPAN' },
+            });
+          } else if (count === 3) {
+            // Third mutation: shadow host removed from container
+            assertMutationEquals(mutations[0]!, {
+              type: 'childList',
+              target: container,
+              removedNodes: { length: 1, tagName: 'DIV' },
+            });
+
+            // Schedule completion check to ensure no fourth mutation occurs
+            if (!completionScheduled) {
+              completionScheduled = true;
+            }
+          } else {
+            throw new Error(`Unexpected mutation count: ${count}`);
+          }
+        }),
+      );
+
+      observer.observe(container, { childList: true, subtree: true });
+
+      container.appendChild(shadowHost);
+      await waitForMutation();
+
+      const shadowChild = document.createElement('span');
+      shadowRoot.appendChild(shadowChild);
+      await waitForMutation();
+
+      container.removeChild(shadowHost);
+      await waitForMutation();
+
+      // Add another element to the shadow root of removed host (should NOT trigger mutation)
+      const anotherShadowChild = document.createElement('p');
+      shadowRoot.appendChild(anotherShadowChild);
+
+      await testComplete;
+    });
+  });
+});

--- a/packages/accented/src/utils/shadow-dom-aware-mutation-observer.ts
+++ b/packages/accented/src/utils/shadow-dom-aware-mutation-observer.ts
@@ -3,9 +3,10 @@ import { isDocument, isDocumentFragment, isElement } from './dom-helpers.js';
 
 function getShadowRoots(elements: Array<Element | Document | DocumentFragment>) {
   return elements
-    .flatMap((element) => Array.from(element.querySelectorAll('*')))
+    .flatMap((element) => [element, ...Array.from(element.querySelectorAll('*'))])
     .reduce<Array<ShadowRoot>>(
-      (acc, element) => (element.shadowRoot ? acc.concat(element.shadowRoot) : acc),
+      (acc, element) =>
+        isElement(element) && element.shadowRoot ? acc.concat(element.shadowRoot) : acc,
       [],
     );
 }

--- a/packages/accented/src/utils/supports-anchor-positioning.ts
+++ b/packages/accented/src/utils/supports-anchor-positioning.ts
@@ -3,7 +3,7 @@
  * since anchor positioning is not working correctly in Safari 26 Technology Preview.
  */
 function isWebKit() {
-  const ua = window.navigator.userAgent;
+  const ua = navigator.userAgent;
   return (/AppleWebKit/.test(ua) && !/Chrome/.test(ua)) || /\b(iPad|iPhone|iPod)\b/.test(ua);
 }
 

--- a/packages/accented/src/utils/supports-anchor-positioning.ts
+++ b/packages/accented/src/utils/supports-anchor-positioning.ts
@@ -1,23 +1,17 @@
-type WindowWithCSS = Window & {
-  CSS: typeof CSS;
-};
-
 /**
  * We have to do browser sniffing now and explicitly turn off Anchor positioning in Safari
  * since anchor positioning is not working correctly in Safari 26 Technology Preview.
  */
-function isWebKit(win: Window) {
-  const ua = win.navigator.userAgent;
+function isWebKit() {
+  const ua = window.navigator.userAgent;
   return (/AppleWebKit/.test(ua) && !/Chrome/.test(ua)) || /\b(iPad|iPhone|iPod)\b/.test(ua);
 }
 
 // ATTENTION: sync with the implementation in end-to-end tests.
 // I didn't find a way to sync this with automatically with the implementation of supportsAnchorPositioning
 // in end-to-end tests, so it has to be synced manually.
-export function supportsAnchorPositioning(win: WindowWithCSS) {
+export function supportsAnchorPositioning() {
   return (
-    win.CSS.supports('anchor-name: --foo') &&
-    win.CSS.supports('position-anchor: --foo') &&
-    !isWebKit(win)
+    CSS.supports('anchor-name: --foo') && CSS.supports('position-anchor: --foo') && !isWebKit()
   );
 }

--- a/packages/accented/src/utils/update-elements-with-issues.test.ts
+++ b/packages/accented/src/utils/update-elements-with-issues.test.ts
@@ -9,76 +9,39 @@ import type { ExtendedElementWithIssues, Issue } from '../types';
 import { updateElementsWithIssues } from './update-elements-with-issues';
 
 const dom = new JSDOM();
-global.window = dom.window as unknown as Window & typeof globalThis;
 global.document = dom.window.document;
-// JSDOM doesn't have CSS, so we mock it
+global.getComputedStyle = dom.window.getComputedStyle;
+// JSDOM doesn't seem to have CSS, so we mock it
 global.CSS = {
   supports: () => true,
 } as any;
-Object.defineProperty(global.window, 'CSS', {
-  value: { supports: () => true },
+// Node already has a global `navigator` object,
+// so we're mocking it differently than other globals.
+Object.defineProperty(global, 'navigator', {
+  value: { userAgent: dom.window.navigator.userAgent },
   writable: true,
-});
-// Mock navigator for browser detection on window
-Object.defineProperty(global.window, 'navigator', {
-  value: { userAgent: '' },
-  writable: true,
+  configurable: true,
 });
 
 type Violation = AxeResults['violations'][number];
 type AxeNode = Violation['nodes'][number];
 
-const win: Window & { CSS: typeof CSS } = {
-  document: {
-    // @ts-expect-error the return value is of incorrect type.
-    createElement: () => ({
-      style: {
-        setProperty: () => {},
-      },
-      dataset: {},
-    }),
-    contains: () => true,
-  },
-  // @ts-expect-error we're missing a lot of properties
-  getComputedStyle: () => ({
-    zIndex: '',
-    direction: 'ltr',
-    getPropertyValue: () => 'none',
-  }),
-  // @ts-expect-error we're missing a lot of properties
-  CSS: {
-    supports: () => true,
-  },
-  // @ts-expect-error we're missing a lot of properties
-  navigator: {
-    userAgent: '',
-  },
-};
+// Create real DOM elements using JSDOM
+const element1 = document.createElement('div');
+element1.setAttribute('id', 'element1');
+document.body.appendChild(element1);
 
-const getBoundingClientRect = () => ({});
+const element2 = document.createElement('div');
+element2.setAttribute('id', 'element2');
+document.body.appendChild(element2);
 
-const getRootNode = (): Node => ({}) as Node;
+const element3 = document.createElement('div');
+element3.setAttribute('id', 'element3');
+// element3 is not connected (not added to document)
 
-const baseElement = {
-  getBoundingClientRect,
-  getRootNode,
-  style: {
-    getPropertyValue: () => '',
-  },
-  closest: () => null,
-};
+const rootNode = document;
 
-// @ts-expect-error element is not HTMLElement
-const element1: HTMLElement = { ...baseElement, isConnected: true };
-// @ts-expect-error element is not HTMLElement
-const element2: HTMLElement = { ...baseElement, isConnected: true };
-// @ts-expect-error element is not HTMLElement
-const element3: HTMLElement = { ...baseElement, isConnected: false };
-
-// @ts-expect-error rootNode is not Node
-const rootNode: Node = {};
-
-const trigger = win.document.createElement('accented-trigger') as AccentedTrigger;
+const trigger = document.createElement('accented-trigger') as AccentedTrigger;
 
 const position = signal({
   left: 0,
@@ -169,7 +132,7 @@ const issue3: Issue = {
 };
 
 const scanContext = {
-  include: [win.document],
+  include: [document],
   exclude: [],
 };
 
@@ -205,7 +168,6 @@ suite('updateElementsWithIssues', () => {
       extendedElementsWithIssues,
       scanContext,
       violations: [violation1, violation2],
-      win,
       name: 'accented',
     });
     assert.equal(extendedElementsWithIssues.value.length, 2);
@@ -246,7 +208,6 @@ suite('updateElementsWithIssues', () => {
       extendedElementsWithIssues,
       scanContext,
       violations: [violation1, violation2, violation3],
-      win,
       name: 'accented',
     });
     assert.equal(extendedElementsWithIssues.value.length, 2);
@@ -287,7 +248,6 @@ suite('updateElementsWithIssues', () => {
       extendedElementsWithIssues,
       scanContext,
       violations: [violation1, violation2],
-      win,
       name: 'accented',
     });
     assert.equal(extendedElementsWithIssues.value.length, 2);
@@ -316,7 +276,6 @@ suite('updateElementsWithIssues', () => {
       extendedElementsWithIssues,
       scanContext,
       violations: [violation1, violation2],
-      win,
       name: 'accented',
     });
     assert.equal(extendedElementsWithIssues.value.length, 2);
@@ -345,7 +304,6 @@ suite('updateElementsWithIssues', () => {
       extendedElementsWithIssues,
       scanContext,
       violations: [violation1, violation4],
-      win,
       name: 'accented',
     });
     assert.equal(extendedElementsWithIssues.value.length, 1);
@@ -383,7 +341,6 @@ suite('updateElementsWithIssues', () => {
       extendedElementsWithIssues,
       scanContext,
       violations: [violation1],
-      win,
       name: 'accented',
     });
     assert.equal(extendedElementsWithIssues.value.length, 1);

--- a/packages/accented/src/utils/update-elements-with-issues.test.ts
+++ b/packages/accented/src/utils/update-elements-with-issues.test.ts
@@ -3,9 +3,27 @@ import { suite, test } from 'node:test';
 import type { Signal } from '@preact/signals-core';
 import { signal } from '@preact/signals-core';
 import type { AxeResults, ImpactValue } from 'axe-core';
+import { JSDOM } from 'jsdom';
 import type { AccentedTrigger } from '../elements/accented-trigger';
 import type { ExtendedElementWithIssues, Issue } from '../types';
 import { updateElementsWithIssues } from './update-elements-with-issues';
+
+const dom = new JSDOM();
+global.window = dom.window as unknown as Window & typeof globalThis;
+global.document = dom.window.document;
+// JSDOM doesn't have CSS, so we mock it
+global.CSS = {
+  supports: () => true,
+} as any;
+Object.defineProperty(global.window, 'CSS', {
+  value: { supports: () => true },
+  writable: true,
+});
+// Mock navigator for browser detection on window
+Object.defineProperty(global.window, 'navigator', {
+  value: { userAgent: '' },
+  writable: true,
+});
 
 type Violation = AxeResults['violations'][number];
 type AxeNode = Violation['nodes'][number];

--- a/packages/accented/src/utils/update-elements-with-issues.ts
+++ b/packages/accented/src/utils/update-elements-with-issues.ts
@@ -36,13 +36,11 @@ export function updateElementsWithIssues({
   extendedElementsWithIssues,
   scanContext,
   violations,
-  win,
   name,
 }: {
   extendedElementsWithIssues: Signal<Array<ExtendedElementWithIssues>>;
   scanContext: ScanContext;
   violations: typeof AxeResults.violations;
-  win: Window & { CSS: typeof CSS };
   name: string;
 }) {
   const updatedElementsWithIssues = transformViolations(violations, name);
@@ -99,9 +97,9 @@ export function updateElementsWithIssues({
             .filter((addedElementWithIssues) => addedElementWithIssues.element.isConnected)
             .map((addedElementWithIssues) => {
               const id = count++;
-              const trigger = win.document.createElement(`${name}-trigger`) as AccentedTrigger;
+              const trigger = document.createElement(`${name}-trigger`) as AccentedTrigger;
               const elementZIndex = Number.parseInt(
-                win.getComputedStyle(addedElementWithIssues.element).zIndex,
+                getComputedStyle(addedElementWithIssues.element).zIndex,
                 10,
               );
               if (!Number.isNaN(elementZIndex)) {
@@ -109,7 +107,7 @@ export function updateElementsWithIssues({
               }
               trigger.style.setProperty('position-anchor', `--${name}-anchor-${id}`, 'important');
               trigger.dataset.id = id.toString();
-              const accentedDialog = win.document.createElement(`${name}-dialog`) as AccentedDialog;
+              const accentedDialog = document.createElement(`${name}-dialog`) as AccentedDialog;
               trigger.dialog = accentedDialog;
               const position = getElementPosition(addedElementWithIssues.element);
               trigger.position = signal(position);
@@ -131,9 +129,7 @@ export function updateElementsWithIssues({
                 scrollableAncestors: signal(scrollableAncestors),
                 anchorNameValue:
                   addedElementWithIssues.element.style.getPropertyValue('anchor-name') ||
-                  win
-                    .getComputedStyle(addedElementWithIssues.element)
-                    .getPropertyValue('anchor-name'),
+                  getComputedStyle(addedElementWithIssues.element).getPropertyValue('anchor-name'),
                 trigger,
                 issues,
               };

--- a/packages/accented/src/utils/update-elements-with-issues.ts
+++ b/packages/accented/src/utils/update-elements-with-issues.ts
@@ -115,9 +115,9 @@ export function updateElementsWithIssues({
               trigger.position = signal(position);
               trigger.visible = signal(true);
               trigger.element = addedElementWithIssues.element;
-              const scrollableAncestors = supportsAnchorPositioning(win)
+              const scrollableAncestors = supportsAnchorPositioning()
                 ? new Set<HTMLElement>()
-                : getScrollableAncestors(addedElementWithIssues.element, win);
+                : getScrollableAncestors(addedElementWithIssues.element);
               const issues = signal(addedElementWithIssues.issues);
               accentedDialog.issues = issues;
               accentedDialog.element = addedElementWithIssues.element;

--- a/packages/accented/src/utils/update-elements-with-issues.ts
+++ b/packages/accented/src/utils/update-elements-with-issues.ts
@@ -111,7 +111,7 @@ export function updateElementsWithIssues({
               trigger.dataset.id = id.toString();
               const accentedDialog = win.document.createElement(`${name}-dialog`) as AccentedDialog;
               trigger.dialog = accentedDialog;
-              const position = getElementPosition(addedElementWithIssues.element, win);
+              const position = getElementPosition(addedElementWithIssues.element);
               trigger.position = signal(position);
               trigger.visible = signal(true);
               trigger.element = addedElementWithIssues.element;

--- a/packages/devapp/test/main.spec.ts
+++ b/packages/devapp/test/main.spec.ts
@@ -431,8 +431,8 @@ test.describe('Accented', () => {
       expect(match).toBeTruthy();
 
       if (match?.[1] && match[3]) {
-        const issueCount = parseInt(match[1]);
-        const elementCount = parseInt(match[3]);
+        const issueCount = parseInt(match[1], 10);
+        const elementCount = parseInt(match[3], 10);
         expect(issueCount).toBeGreaterThan(0);
         expect(elementCount).toBeGreaterThan(0);
       }

--- a/packages/website/scripts/checkLinks.mjs
+++ b/packages/website/scripts/checkLinks.mjs
@@ -67,9 +67,9 @@ async function extractUrlsFromSitemap(host) {
   }
 }
 
-async function runToCompletion(process, args) {
+async function runToCompletion(process, processArgs) {
   return new Promise((resolve, reject) => {
-    const spawnedProcess = spawn(process, args, {
+    const spawnedProcess = spawn(process, processArgs, {
       stdio: 'inherit',
     });
 

--- a/packages/website/src/components/MainMenu.astro
+++ b/packages/website/src/components/MainMenu.astro
@@ -39,12 +39,12 @@ const menuItems: Array<MenuItem> = [
   { id: 'github', href: 'https://github.com/pomerantsev/accented', icon: 'Github' },
 ];
 
-function isCurrent(item: MenuItem, pathname: string): boolean {
+function isCurrent(item: MenuItem, itemPathname: string): boolean {
   if ('text' in item) {
-    if (item.id === 'blog' && pathname.startsWith('/blog/')) {
+    if (item.id === 'blog' && itemPathname.startsWith('/blog/')) {
       return true;
     }
-    return pathname === item.href;
+    return itemPathname === item.href;
   }
   return false;
 }

--- a/packages/website/src/pages/blog/[post].astro
+++ b/packages/website/src/pages/blog/[post].astro
@@ -10,12 +10,12 @@ export async function getStaticPaths() {
 
 const { post: postId } = Astro.params;
 
-const post = await getEntry('blog', postId);
-if (!post) {
+const currentPost = await getEntry('blog', postId);
+if (!currentPost) {
   throw new Error(`Post with ID "${postId}" not found.`);
 }
 
-const { Content } = await render(post);
+const { Content } = await render(currentPost);
 ---
 <style>
   nav {
@@ -42,19 +42,19 @@ const { Content } = await render(post);
   }
 </style>
 
-<MainLayout title={`${post.data.title} | Blog`} description={post.data.description}>
+<MainLayout title={`${currentPost.data.title} | Blog`} description={currentPost.data.description}>
   <nav aria-label="Breadcrumbs">
     <a href="/blog">← All posts</a>
   </nav>
   <article class="flow">
-    <h1>{post.data.title}</h1>
+    <h1>{currentPost.data.title}</h1>
     <p class="metadata">
-      <time datetime={getPostDate(post)}>{formatPostDate(post)}</time>, by {
-        post.data.author
+      <time datetime={getPostDate(currentPost)}>{formatPostDate(currentPost)}</time>, by {
+        currentPost.data.author
       }
     </p>
     <p class="subtitle">
-      {post.data.description}
+      {currentPost.data.description}
     </p>
     <Content />
   </article>


### PR DESCRIPTION
* Change how `ShadowDOMAwareMutationObserver` works: previously, it was one `MutationObserver` instance observing all root nodes, likely leading to memory leaks since there would be no unobserving of disconnected nodes; now we create a separate mutation observer per shadow root and manually clean up by disconnecting it when needed.
* Refactor `ShadowDOMAwareMutationObserver`.
* Add unit tests for `ShadowDOMAwareMutationObserver`.
* Add a couple of new Biome rules (including `noShadow`).
* Mock global objects like `window` using `JSDOM` in tests instead of having to pass it as a parameter (which looked gross).