### PR TITLE
Fix redirects on website

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -12,6 +12,9 @@ export default defineConfig({
   publicDir: './public',
   site: 'https://accented.dev',
   trailingSlash: 'never',
+  build: {
+    format: 'file',
+  },
   image: {
     responsiveStyles: true,
   },

--- a/packages/website/src/components/TableOfContents.astro
+++ b/packages/website/src/components/TableOfContents.astro
@@ -7,7 +7,9 @@ type Heading = {
 
 const matches = import.meta.glob('~/pages/*.md(x)?', { eager: true });
 const pages = Object.values(matches) as Array<{ url: string; getHeadings: () => Array<Heading> }>;
-const currentPage = pages.find((page) => page.url === Astro.url.pathname.replace(/^(.+)\/$/, '$1'));
+const currentPage = pages.find(
+  (page) => page.url === Astro.url.pathname.replace(/^(.+)\.html$/, '$1'),
+);
 const headings = currentPage?.getHeadings() || [];
 
 type TocItem = {


### PR DESCRIPTION
A redirect is currently always happening in prod (from something like /api to /api/).

To remove the trailing slash, we have to generate not /api/index.html, but /api.html.


