### PR TITLE
Automate accented version updates in playground after publishing

### DIFF
--- a/.github/workflows/accented.yml
+++ b/.github/workflows/accented.yml
@@ -2,11 +2,21 @@ name: Accented
 
 on:
   push:
+  workflow_dispatch:
+    inputs:
+      mock_publish:
+        description: 'Mock a successful publish to test the playground update workflow'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build-test-publish:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.mock.outputs.published || steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.mock.outputs.publishedPackages || steps.changesets.outputs.publishedPackages }}
     permissions:
       id-token: write
       contents: write
@@ -47,6 +57,7 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
 
       - name: Create release PR or publish
+        id: changesets
         if: github.ref == 'refs/heads/main'
         uses: changesets/action@v1
         with:
@@ -66,3 +77,53 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Mock outputs for testing
+        id: mock
+        if: inputs.mock_publish == 'true'
+        run: |
+          echo "published=true" >> $GITHUB_OUTPUT
+          echo "publishedPackages=[{\"name\":\"accented\",\"version\":\"1.0.0\"}]" >> $GITHUB_OUTPUT
+          echo "Mock: Simulating publication of accented@1.0.0"
+
+  update-playground:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    needs: build-test-publish
+    if: |
+      (github.ref == 'refs/heads/main' && needs.build-test-publish.outputs.published == 'true' && contains(needs.build-test-publish.outputs.publishedPackages, '"accented"')) ||
+      inputs.mock_publish == 'true'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Extract version from changesets output
+        id: version
+        run: |
+          # Extract version from publishedPackages JSON
+          VERSION=$(echo '${{ needs.build-test-publish.outputs.publishedPackages }}' | jq -r '.[] | select(.name == "accented") | .version')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Update playground dependency
+        run: pnpm -F playground add -D accented@^${{ steps.version.outputs.version }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          commit-message: "Bump accented to ${{ steps.version.outputs.version }}"
+          title: "Bump accented to ${{ steps.version.outputs.version }}"
+          body: |
+            Automated update of `accented` dependency in playground to version `^${{ steps.version.outputs.version }}`.
+
+            This PR was automatically created after publishing accented@${{ steps.version.outputs.version }}.
+          branch: update-playground-accented-${{ steps.version.outputs.version }}
+          delete-branch: true


### PR DESCRIPTION
* After a new version of Accented is published, extract that from the output and create a new PR that bumps the version of accented in the playground package.
* For testing, add a `mock_publish` input to the workflow that makes it look like version 1.0.0 got published, and triggers the creation of the PR with that version.