### PR TITLE
Fix and clean up the Update Playground workflow

### DIFF
--- a/.github/workflows/accented.yml
+++ b/.github/workflows/accented.yml
@@ -11,12 +11,21 @@ on:
         type: boolean
 
 jobs:
+  mock-publish:
+    if: ${{ inputs.mock_publish }}
+    runs-on: ubuntu-latest
+    outputs:
+      publishedPackages: '[{"name":"accented","version":"1.0.0"}]'
+    steps:
+      - name: Mock publish completed
+        run: echo "Mock - Simulating publication of accented@1.0.0"
+
   build-test-publish:
+    if: ${{ !inputs.mock_publish }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     outputs:
-      published: ${{ steps.mock.outputs.published || steps.changesets.outputs.published }}
-      publishedPackages: ${{ steps.mock.outputs.publishedPackages || steps.changesets.outputs.publishedPackages }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     permissions:
       id-token: write
       contents: write
@@ -78,21 +87,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
-      - name: Mock outputs for testing
-        id: mock
-        if: inputs.mock_publish == 'true'
-        run: |
-          echo "published=true" >> $GITHUB_OUTPUT
-          echo "publishedPackages=[{\"name\":\"accented\",\"version\":\"1.0.0\"}]" >> $GITHUB_OUTPUT
-          echo "Mock: Simulating publication of accented@1.0.0"
-
   update-playground:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    needs: build-test-publish
+    needs: [mock-publish, build-test-publish]
     if: |
-      (github.ref == 'refs/heads/main' && needs.build-test-publish.outputs.published == 'true' && contains(needs.build-test-publish.outputs.publishedPackages, '"accented"')) ||
-      inputs.mock_publish == 'true'
+      always() && (
+        contains(needs.mock-publish.outputs.publishedPackages, '"accented"') ||
+        (github.ref == 'refs/heads/main' && contains(needs.build-test-publish.outputs.publishedPackages, '"accented"'))
+      )
     permissions:
       contents: write
       pull-requests: write
@@ -104,11 +107,16 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Extract version from changesets output
+      - name: Extract version from outputs
         id: version
         run: |
-          # Extract version from publishedPackages JSON
-          VERSION=$(echo '${{ needs.build-test-publish.outputs.publishedPackages }}' | jq -r '.[] | select(.name == "accented") | .version')
+          # Extract version from publishedPackages JSON (from either mock or real job)
+          if [[ "${{ needs.mock-publish.result }}" == "success" ]]; then
+            PACKAGES='${{ needs.mock-publish.outputs.publishedPackages }}'
+          else
+            PACKAGES='${{ needs.build-test-publish.outputs.publishedPackages }}'
+          fi
+          VERSION=$(echo "$PACKAGES" | jq -r '.[] | select(.name == "accented") | .version')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 


### PR DESCRIPTION
* Fix how `mock_publish` is checked (it's a boolean, not a string).
* Skip the `build-test-publish` job altogether if we're mocking the publish results.
* Get rid of the `published` output (it seemed redundant).