### PR TITLE
Exclude npmjs.com links from scanning

### DIFF
--- a/packages/website/scripts/checkLinks.mjs
+++ b/packages/website/scripts/checkLinks.mjs
@@ -86,6 +86,8 @@ async function runToCompletion(process, processArgs) {
 const commonLycheeArgs = [
   '--exclude',
   '/sitemap-index.xml$',
+  '--exclude',
+  '^https://www.npmjs.com/', // npmjs.com enabled Cloudflare security, which blocks curl requests
   '--verbose',
   '--cache',
   '--max-retries',


### PR DESCRIPTION
There's now Cloudflare's anti-bot protection, which means that for curl or Lychee requests, a 403 is returned.


