### PR TITLE
Enable Biome explicitly in the example VS Code settings

### DIFF
--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -2,6 +2,9 @@
 // to enable fixing / formatting on save for this project.
 
 {
+  /* Enables Biome for the project */
+  "biome.enabled": true,
+
   /* Sets Biome as the default formatter for all supported file types */
   "editor.defaultFormatter": "biomejs.biome",
 


### PR DESCRIPTION
Doing this instead of having to rely on a global setting that enables Biome.


