### PR TITLE
Remove special case for anchor positioning in Safari

### DIFF
--- a/.changeset/small-schools-bathe.md
+++ b/.changeset/small-schools-bathe.md
@@ -1,0 +1,5 @@
+---
+"accented": patch
+---
+
+Re-enable anchor positioning in Safari

--- a/packages/accented/src/utils/supports-anchor-positioning.ts
+++ b/packages/accented/src/utils/supports-anchor-positioning.ts
@@ -1,17 +1,6 @@
-/**
- * We have to do browser sniffing now and explicitly turn off Anchor positioning in Safari
- * since anchor positioning is not working correctly in Safari 26 Technology Preview.
- */
-function isWebKit() {
-  const ua = navigator.userAgent;
-  return (/AppleWebKit/.test(ua) && !/Chrome/.test(ua)) || /\b(iPad|iPhone|iPod)\b/.test(ua);
-}
-
 // ATTENTION: sync with the implementation in end-to-end tests.
 // I didn't find a way to sync this with automatically with the implementation of supportsAnchorPositioning
 // in end-to-end tests, so it has to be synced manually.
 export function supportsAnchorPositioning() {
-  return (
-    CSS.supports('anchor-name: --foo') && CSS.supports('position-anchor: --foo') && !isWebKit()
-  );
+  return CSS.supports('anchor-name: --foo') && CSS.supports('position-anchor: --foo');
 }

--- a/packages/devapp/test/main.spec.ts
+++ b/packages/devapp/test/main.spec.ts
@@ -15,16 +15,10 @@ const accentedTriggerElementName = 'accented-trigger';
 
 const supportsAnchorPositioning = async (page: Page) =>
   await page.evaluate(() => {
-    function isWebKit() {
-      const ua = navigator.userAgent;
-      return (/AppleWebKit/.test(ua) && !/Chrome/.test(ua)) || /\b(iPad|iPhone|iPod)\b/.test(ua);
-    }
     // ATTENTION: sync with the implementation in the library.
     // I didn't find a way to sync this with automatically with the implementation of supportsAnchorPositioning
     // in the library, so it has to be synced manually.
-    return (
-      CSS.supports('anchor-name: --foo') && CSS.supports('position-anchor: --foo') && !isWebKit()
-    );
+    return CSS.supports('anchor-name: --foo') && CSS.supports('position-anchor: --foo');
   });
 
 test.describe('Accented', () => {


### PR DESCRIPTION
Anchor positioning in Safari 26.0 was buggy (see
https://github.com/Fyrd/caniuse/pull/7387), so I had to create a special case to never use anchor positioning in that browser.

Now the bugs are fixed, and Accented no longer supports 26.0, so it's time to retire this special case.

Resolves #397 

