### PR TITLE
Fix positioning of Accented triggers on transformed elements in Chrome 144+

### DIFF
--- a/.changeset/fresh-readers-leave.md
+++ b/.changeset/fresh-readers-leave.md
@@ -1,0 +1,5 @@
+---
+"accented": patch
+---
+
+Fix positioning of Accented triggers on transformed elements in Chrome 144+

--- a/packages/accented/src/accented.ts
+++ b/packages/accented/src/accented.ts
@@ -10,6 +10,7 @@ import { setupScrollListeners } from './scroll-listeners.js';
 import { enabled, extendedElementsWithIssues } from './state.js';
 import type { AccentedOptions, DisableAccented } from './types.ts';
 import { initializeContainingBlockSupportSet } from './utils/containing-blocks.js';
+import { initializeCssTransformsCheck } from './utils/css-transforms.js';
 import { deepMerge } from './utils/deep-merge.js';
 import { supportsAnchorPositioning } from './utils/supports-anchor-positioning.js';
 import { validateOptions } from './validate-options.js';
@@ -92,6 +93,7 @@ export function accented(options: AccentedOptions = {}): DisableAccented {
     enabled.value = true;
 
     initializeContainingBlockSupportSet();
+    initializeCssTransformsCheck();
     registerElements(name);
 
     const { disconnect: cleanupIntersectionObserver, intersectionObserver } =

--- a/packages/accented/src/elements/accented-trigger.ts
+++ b/packages/accented/src/elements/accented-trigger.ts
@@ -3,6 +3,7 @@ import { effect } from '@preact/signals-core';
 import { fontSystemSans } from '../common/tokens.js';
 import { logAndRethrow } from '../log-and-rethrow.js';
 import type { Position } from '../types.ts';
+import { cssTransformsAffectAnchorPositioning } from '../utils/css-transforms.js';
 import { supportsAnchorPositioning } from '../utils/supports-anchor-positioning.js';
 import type { AccentedDialog } from './accented-dialog.ts';
 
@@ -241,6 +242,9 @@ export const getAccentedTrigger = (name: string) => {
     }
 
     #setTransform() {
+      if (cssTransformsAffectAnchorPositioning()) {
+        return;
+      }
       // We read and write values in separate animation frames to avoid layout thrashing.
       window.requestAnimationFrame(() => {
         if (this.element) {

--- a/packages/accented/src/utils/css-transforms.ts
+++ b/packages/accented/src/utils/css-transforms.ts
@@ -1,0 +1,42 @@
+/**
+ * Some browsers (at the time of this writing, Chrome 144+) started to take CSS transforms into account
+ * when calculating the position of the anchored element.
+ *
+ * In light of this, this utility helps determine if we need to apply a separate transform to the anchored element
+ * when it's added to the DOM.
+ */
+
+let doesAffect: boolean;
+
+export function cssTransformsAffectAnchorPositioning() {
+  return doesAffect;
+}
+
+/**
+ * This function is supposed to run once at library initialization.
+ * It creates two elements (an anchor and an anchored element),
+ * with a transform applied to the anchor, and determines whether
+ * their positions still match.
+ */
+export function initializeCssTransformsCheck() {
+  const anchor = document.createElement('div');
+  anchor.style.inlineSize = '100px';
+  anchor.style.blockSize = '100px';
+  anchor.style.transform = 'translateX(100px)';
+  // @ts-expect-error TS is unaware of `anchor-name`
+  anchor.style.anchorName = '--test-anchor';
+
+  const anchored = document.createElement('div');
+  anchored.style.inlineSize = '10px';
+  anchored.style.blockSize = '10px';
+  anchored.style.position = 'absolute';
+  // @ts-expect-error TS is unaware of `position-anchor`
+  anchored.style.positionAnchor = '--test-anchor';
+  anchored.style.insetInlineStart = 'anchor(start)';
+  anchored.style.insetBlockStart = 'anchor(start)';
+
+  document.body.appendChild(anchor);
+  document.body.appendChild(anchored);
+
+  doesAffect = anchor.getBoundingClientRect().left === anchored.getBoundingClientRect().left;
+}

--- a/packages/devapp/test/helpers/trigger.ts
+++ b/packages/devapp/test/helpers/trigger.ts
@@ -45,8 +45,4 @@ export async function expectElementAndTriggerToBeAligned(
   expect(triggerRect[side]).toBeLessThan(elementRect[side] + 2);
   expect(triggerRect.top).toBeGreaterThan(elementRect.top - 2);
   expect(triggerRect.top).toBeLessThan(elementRect.top + 2);
-
-  const elementTransform = await getTransform(element);
-  const triggerContainerTransform = await getTransform(triggerContainer);
-  expect(elementTransform).toBe(triggerContainerTransform);
 }


### PR DESCRIPTION
Chrome 144 started to take the anchor's CSS transforms into account when calculating an anchored element's position. This seems to be in line with the [spec](https://www.w3.org/TR/css-anchor-position-1/), so other browsers may start doing the same as well.

While the browser behavior is different, we will be determining the behavior at library initialization.

Before (Chrome 144):

<img width="356" height="129" alt="A button with an Accented trigger that's visibly misaligned with it, especially in the horizontal axis" src="https://github.com/user-attachments/assets/719bc8ce-dd97-40b9-9cf6-8a10838b76b3" />

After (Chrome 144):

<img width="355" height="127" alt="A button with an Accented trigger, both aligned with each other, vertically and horizontally" src="https://github.com/user-attachments/assets/ae176330-cb65-4a28-8140-738f973f0e1a" />
