### PR TITLE
Address issues with Biome updater workflow

### DIFF
--- a/.github/workflows/update-biome-schema.yml
+++ b/.github/workflows/update-biome-schema.yml
@@ -2,7 +2,7 @@ name: Update Biome schema
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   update-biome-schema:
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
 
       - name: Extract new biome version
         id: version


### PR DESCRIPTION
* Personal github token couldn't be used by dependabot-generated PRs, trying to make it default to the regular GITHUB_TOKEN.
* Workflow would not run when a PR was force-pushed to, hopefully `synchronize` is the solution.


