### PR TITLE
Make install work again with pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,9 @@
 packages:
   - packages/*
 
-onlyBuiltDependencies:
-  - "@parcel/watcher"
-  - "@tailwindcss/oxide"
-  - esbuild
-  - netlify-cli
-  - sharp
-  - unix-dgram
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  netlify-cli: true
+  sharp: true
+  unix-dgram: true


### PR DESCRIPTION
See `allowBuilds` in https://github.com/pnpm/pnpm/releases/tag/v11.0.0

Also, looks like `@tailwindcss/oxide` doesn't include a build step anymore, so that got completely removed.