### PR TITLE
Dependency / changelog cleanup + axe-core version bump

### DIFF
--- a/.changeset/violet-taxis-drum.md
+++ b/.changeset/violet-taxis-drum.md
@@ -1,0 +1,5 @@
+---
+"accented": patch
+---
+
+Bump axe-core to 4.11.4

--- a/.github/workflows/accented.yml
+++ b/.github/workflows/accented.yml
@@ -89,7 +89,7 @@ jobs:
           echo "Extracted version: $VERSION"
 
       - name: Update playground dependency
-        run: pnpm -F playground add -D accented@^${{ steps.version.outputs.version }}
+        run: pnpm -F playground add -D accented@${{ steps.version.outputs.version }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
@@ -98,7 +98,7 @@ jobs:
           commit-message: "Bump accented to ${{ steps.version.outputs.version }}"
           title: "Bump accented to ${{ steps.version.outputs.version }}"
           body: |
-            Automated update of `accented` dependency in playground to version `^${{ steps.version.outputs.version }}`.
+            Automated update of `accented` dependency in playground to version `${{ steps.version.outputs.version }}`.
 
             This PR was automatically created after publishing accented@${{ steps.version.outputs.version }}.
           branch: update-playground-accented-${{ steps.version.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@ node_modules
 tsconfig.tsbuildinfo
 tsconfig.test.tsbuildinfo
 
-# Prevent .npmrc that is filled with the NPM token in CI from leaking to pull requests
-.npmrc
-
 # Local Netlify folder
 .netlify
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,11 @@ That's even true for cases where the specificity of a host app selector is highe
   - Font family: Noto Sans
   - Font variant: Regular 400 Normal
   - Font size: 110
+- package.json: pin versions for most dependencies
+  - For contributors, the source of truth is the lockfile anyway, so for most dependencies it doesn’t matter how they're specified in the package.json.
+  - Pinning dependencies in the playground gives maintainers more confidence that a non-major upgrade in one of them doesn’t break the playground for a visitor.
+  - The only exception is the runtime dependencies of Accented itself. This will allow consumers to deduplicate their deps and receive patch or minor upgrades
+    without waiting for a new Accented version. Caret ranges for runtime dependencies are standard practice for published NPM packages.
 
 ## Known issues / limitations
 

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
-    "@changesets/changelog-github": "^0.7.0",
-    "@changesets/cli": "^2.31.0",
-    "@playwright/test": "^1.60.0",
-    "@types/node": "^25.8.0",
-    "husky": "^9.1.7",
-    "lint-staged": "^17.0.5",
-    "rimraf": "^6.1.3",
-    "tsx": "^4.22.1",
-    "typescript": "^6.0.3"
+    "@changesets/changelog-github": "0.7.0",
+    "@changesets/cli": "2.31.0",
+    "@playwright/test": "1.60.0",
+    "@types/node": "25.8.0",
+    "husky": "9.1.7",
+    "lint-staged": "17.0.5",
+    "rimraf": "6.1.3",
+    "tsx": "4.22.1",
+    "typescript": "6.0.3"
   }
 }

--- a/packages/accented/CHANGELOG.md
+++ b/packages/accented/CHANGELOG.md
@@ -7,27 +7,31 @@
 - Fix false positives and false negatives for some axe-core rules ([#482](https://github.com/pomerantsev/accented/pull/482))
   **Important:** this fix _might_ lead to a slight decrease in runtime performance on complex pages.
 
-### Patch Changes
+### Dependencies
 
-- Bump axe-core to 4.11.3 ([#491](https://github.com/pomerantsev/accented/pull/491))
+- axe-core 4.11.3 ([#491](https://github.com/pomerantsev/accented/pull/491))
 
-- Bump typescript to 6.0.3 (no functional changes) ([#480](https://github.com/pomerantsev/accented/pull/480))
+### Build
+
+- typescript 6.0.3 ([#480](https://github.com/pomerantsev/accented/pull/480))
 
 ## 1.2.6
 
-### Patch Changes
+### Dependencies
 
-- Bump axe-core to 4.11.2 ([#469](https://github.com/pomerantsev/accented/pull/469))
+- axe-core 4.11.2 ([#469](https://github.com/pomerantsev/accented/pull/469))
 
-- Bump @preact/signals-core to 1.14.1 (no functional changes) ([#471](https://github.com/pomerantsev/accented/pull/471))
+- @preact/signals-core 1.14.1 ([#471](https://github.com/pomerantsev/accented/pull/471))
 
-- Bump typescript to 6.0.2 (no functional changes) ([#474](https://github.com/pomerantsev/accented/pull/474))
+### Build
+
+- typescript 6.0.2 ([#474](https://github.com/pomerantsev/accented/pull/474))
 
 ## 1.2.5
 
-### Patch Changes
+### Dependencies
 
-- Bump @preact/signals-core to 1.14.0 (no functional changes) ([#451](https://github.com/pomerantsev/accented/pull/451), [#461](https://github.com/pomerantsev/accented/pull/461))
+- @preact/signals-core 1.14.0 ([#451](https://github.com/pomerantsev/accented/pull/451), [#461](https://github.com/pomerantsev/accented/pull/461))
 
 ## 1.2.4
 
@@ -35,13 +39,15 @@
 
 - Fix positioning of Accented triggers on transformed elements in Chrome 144+ ([#443](https://github.com/pomerantsev/accented/pull/443), [#445](https://github.com/pomerantsev/accented/pull/445))
 
-- Bump @preact/signals-core to 1.12.2 (no functional changes) ([#436](https://github.com/pomerantsev/accented/pull/436))
+### Dependencies
+
+- @preact/signals-core 1.12.2 ([#436](https://github.com/pomerantsev/accented/pull/436))
 
 ## 1.2.3
 
-### Patch Changes
+### Dependencies
 
-- Bump axe-core from 4.11.0 to 4.11.1 ([#416](https://github.com/pomerantsev/accented/pull/416))
+- axe-core 4.11.1 ([#416](https://github.com/pomerantsev/accented/pull/416))
 
 ## 1.2.2
 
@@ -55,17 +61,19 @@
 
 - Fix: passing a `context` object with missing `include` led to unexpected and incorrect scan context ([#361](https://github.com/pomerantsev/accented/pull/361))
 
-- Bump TS target to ES 2024 (no functional changes) ([#362](https://github.com/pomerantsev/accented/pull/362))
+### Build
+
+- TypeScript target: ES 2024 ([#362](https://github.com/pomerantsev/accented/pull/362))
 
 ## 1.2.0
 
-### Minor Changes
+### Dependencies
 
-- Bump axe-core from 4.10.3 to 4.11.0 ([#347](https://github.com/pomerantsev/accented/pull/347))
+- axe-core 4.11.0 (minor upgrade) ([#347](https://github.com/pomerantsev/accented/pull/347))
 
-### Patch Changes
+### Build
 
-- Bump typescript from 5.9.2 to 5.9.3 (no functional changes) ([#331](https://github.com/pomerantsev/accented/pull/331))
+- typescript 5.9.3 ([#331](https://github.com/pomerantsev/accented/pull/331))
 
 ## 1.1.2
 
@@ -73,7 +81,9 @@
 
 - Fix some edge cases in ShadowDOMAwareMutationObserver ([#300](https://github.com/pomerantsev/accented/pull/300))
 
-- Bump @preact/signals-core from 1.11.0 to 1.12.1 (no functional changes) ([#301](https://github.com/pomerantsev/accented/pull/301))
+### Dependencies
+
+- @preact/signals-core 1.12.1 ([#301](https://github.com/pomerantsev/accented/pull/301))
 
 ## 1.1.1
 
@@ -89,9 +99,9 @@
 
 - Add `output.page` option to support console-only mode ([#268](https://github.com/pomerantsev/accented/pull/268))
 
-### Patch Changes
+### Build
 
-- Bump typescript from 5.8.3 to 5.9.2 (no functional changes) ([#252](https://github.com/pomerantsev/accented/pull/252))
+- typescript 5.9.2 ([#252](https://github.com/pomerantsev/accented/pull/252))
 
 ## 1.0.1
 
@@ -99,7 +109,9 @@
 
 - Fix trigger positioning in Safari Technology Preview ([`f503408`](https://github.com/pomerantsev/accented/commit/f503408d59f47d5b2f9737d058ad7a61213dea1a))
 
-- Bump @preact/signals-core to 1.11.0 (no functional changes) ([#214](https://github.com/pomerantsev/accented/pull/214))
+### Dependencies
+
+- @preact/signals-core 1.11.0 ([#214](https://github.com/pomerantsev/accented/pull/214))
 
 ## 1.0.0
 
@@ -171,7 +183,13 @@
 
 - Fix trigger visibility in Chrome when overflowing overflow: visible containers ([#160](https://github.com/pomerantsev/accented/pull/160))
 
-- Upgrade axe-core and typescript ([#147](https://github.com/pomerantsev/accented/pull/147))
+### Dependencies
+
+- axe-core 4.10.3 ([#147](https://github.com/pomerantsev/accented/pull/147))
+
+### Build
+
+- typescript 5.8.3 ([#147](https://github.com/pomerantsev/accented/pull/147))
 
 ## 0.0.2
 

--- a/packages/accented/package.json
+++ b/packages/accented/package.json
@@ -42,7 +42,7 @@
     "axe-core": "^4.11.3"
   },
   "devDependencies": {
-    "@types/jsdom": "^28.0.3",
-    "jsdom": "^29.0.2"
+    "@types/jsdom": "28.0.3",
+    "jsdom": "29.1.1"
   }
 }

--- a/packages/accented/package.json
+++ b/packages/accented/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://accented.dev",
   "dependencies": {
     "@preact/signals-core": "^1.14.2",
-    "axe-core": "^4.11.3"
+    "axe-core": "^4.11.4"
   },
   "devDependencies": {
     "@types/jsdom": "28.0.3",

--- a/packages/devapp/package.json
+++ b/packages/devapp/package.json
@@ -10,8 +10,8 @@
     "test-buildless": "playwright test test/buildless.spec.ts"
   },
   "devDependencies": {
-    "axe-core": "^4.11.3",
-    "vite": "^8.0.14"
+    "axe-core": "4.11.4",
+    "vite": "8.0.14"
   },
   "dependencies": {
     "accented": "workspace:*"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,21 +11,21 @@
     "typecheck": "tsc --noEmit --project tsconfig.app.json"
   },
   "dependencies": {
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
-    "react-icons": "^5.6.0"
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
+    "react-icons": "5.6.0"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.2.4",
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
-    "accented": "^1.3.0",
-    "autoprefixer": "^10.5.0",
-    "globals": "^17.5.0",
-    "postcss": "^8.5.15",
-    "tailwindcss": "^4.2.4",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.14"
+    "@tailwindcss/postcss": "4.3.0",
+    "@types/react": "19.2.15",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.2",
+    "accented": "1.3.0",
+    "autoprefixer": "10.5.0",
+    "globals": "17.6.0",
+    "postcss": "8.5.15",
+    "tailwindcss": "4.3.0",
+    "typescript": "6.0.3",
+    "vite": "8.0.14"
   }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -15,29 +15,29 @@
     "db:studio": "netlify dev:exec drizzle-kit studio"
   },
   "dependencies": {
-    "@astrojs/mdx": "^5.0.6",
-    "@astrojs/netlify": "^7.0.10",
-    "@astrojs/rss": "^4.0.18",
-    "@astrojs/sitemap": "^3.7.2",
-    "@cloudfour/image-compare": "^1.0.5",
-    "@fontsource-variable/ibm-plex-sans": "^5.2.8",
-    "@fontsource-variable/lora": "^5.2.8",
-    "@fontsource/ibm-plex-mono": "^5.2.7",
-    "astro": "^6.3.5",
+    "@astrojs/mdx": "5.0.6",
+    "@astrojs/netlify": "7.0.10",
+    "@astrojs/rss": "4.0.18",
+    "@astrojs/sitemap": "3.7.2",
+    "@cloudfour/image-compare": "1.0.5",
+    "@fontsource-variable/ibm-plex-sans": "5.2.8",
+    "@fontsource-variable/lora": "5.2.8",
+    "@fontsource/ibm-plex-mono": "5.2.7",
+    "astro": "6.3.5",
     "common": "workspace:*",
-    "drizzle-orm": "^0.45.2",
-    "postgres": "^3.4.9",
-    "rehype-slug": "^6.0.0",
-    "sharp": "^0.34.5",
-    "shiki": "^4.0.2",
-    "ua-parser-js": "^2.0.9",
-    "unist-util-visit": "^5.1.0",
-    "web-vitals": "^5.2.0"
+    "drizzle-orm": "0.45.2",
+    "postgres": "3.4.9",
+    "rehype-slug": "6.0.0",
+    "sharp": "0.34.5",
+    "shiki": "4.0.2",
+    "ua-parser-js": "2.0.9",
+    "unist-util-visit": "5.1.0",
+    "web-vitals": "5.2.0"
   },
   "devDependencies": {
-    "@astrojs/check": "^0.9.9",
+    "@astrojs/check": "0.9.9",
     "accented": "workspace:*",
-    "drizzle-kit": "^0.31.10",
-    "netlify-cli": "^26.0.2"
+    "drizzle-kit": "0.31.10",
+    "netlify-cli": "26.0.2"
   }
 }

--- a/packages/website/src/pages/about.mdx
+++ b/packages/website/src/pages/about.mdx
@@ -65,6 +65,7 @@ In practice, here’s how we decide whether a release should be major, minor, or
 
 - A non-breaking (additive) API change.
 - A behavioral change that isn’t a bug fix (for example, when Accented starts reporting a new class of issues).
+- A minor or major runtime dependency bump (as long as it doesn’t break the Accented API).
 
 **Patch:**
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         specifier: ^1.14.2
         version: 1.14.2
       axe-core:
-        specifier: ^4.11.3
+        specifier: ^4.11.4
         version: 4.11.4
     devDependencies:
       '@types/jsdom':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,31 +12,31 @@ importers:
         specifier: 2.4.15
         version: 2.4.15
       '@changesets/changelog-github':
-        specifier: ^0.7.0
+        specifier: 0.7.0
         version: 0.7.0
       '@changesets/cli':
-        specifier: ^2.31.0
+        specifier: 2.31.0
         version: 2.31.0(@types/node@25.8.0)
       '@playwright/test':
-        specifier: ^1.60.0
+        specifier: 1.60.0
         version: 1.60.0
       '@types/node':
-        specifier: ^25.8.0
+        specifier: 25.8.0
         version: 25.8.0
       husky:
-        specifier: ^9.1.7
+        specifier: 9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^17.0.5
+        specifier: 17.0.5
         version: 17.0.5
       rimraf:
-        specifier: ^6.1.3
+        specifier: 6.1.3
         version: 6.1.3
       tsx:
-        specifier: ^4.22.1
+        specifier: 4.22.1
         version: 4.22.1
       typescript:
-        specifier: ^6.0.3
+        specifier: 6.0.3
         version: 6.0.3
 
   packages/accented:
@@ -49,10 +49,10 @@ importers:
         version: 4.11.4
     devDependencies:
       '@types/jsdom':
-        specifier: ^28.0.3
+        specifier: 28.0.3
         version: 28.0.3
       jsdom:
-        specifier: ^29.0.2
+        specifier: 29.1.1
         version: 29.1.1
 
   packages/common: {}
@@ -64,126 +64,126 @@ importers:
         version: link:../accented
     devDependencies:
       axe-core:
-        specifier: ^4.11.3
+        specifier: 4.11.4
         version: 4.11.4
       vite:
-        specifier: ^8.0.14
+        specifier: 8.0.14
         version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
   packages/playground:
     dependencies:
       react:
-        specifier: ^19.2.5
+        specifier: 19.2.6
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.5
+        specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
       react-icons:
-        specifier: ^5.6.0
+        specifier: 5.6.0
         version: 5.6.0(react@19.2.6)
     devDependencies:
       '@tailwindcss/postcss':
-        specifier: ^4.2.4
+        specifier: 4.3.0
         version: 4.3.0
       '@types/react':
-        specifier: ^19.2.15
+        specifier: 19.2.15
         version: 19.2.15
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
-        specifier: ^6.0.2
+        specifier: 6.0.2
         version: 6.0.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       accented:
-        specifier: ^1.3.0
+        specifier: 1.3.0
         version: 1.3.0
       autoprefixer:
-        specifier: ^10.5.0
+        specifier: 10.5.0
         version: 10.5.0(postcss@8.5.15)
       globals:
-        specifier: ^17.5.0
+        specifier: 17.6.0
         version: 17.6.0
       postcss:
-        specifier: ^8.5.15
+        specifier: 8.5.15
         version: 8.5.15
       tailwindcss:
-        specifier: ^4.2.4
+        specifier: 4.3.0
         version: 4.3.0
       typescript:
-        specifier: ^6.0.3
+        specifier: 6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.0.14
+        specifier: 8.0.14
         version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
   packages/website:
     dependencies:
       '@astrojs/mdx':
-        specifier: ^5.0.6
+        specifier: 5.0.6
         version: 5.0.6(astro@6.3.5(@netlify/blobs@10.7.8)(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0))
       '@astrojs/netlify':
-        specifier: ^7.0.10
+        specifier: 7.0.10
         version: 7.0.10(@types/node@25.9.1)(astro@6.3.5(@netlify/blobs@10.7.8)(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0)
       '@astrojs/rss':
-        specifier: ^4.0.18
+        specifier: 4.0.18
         version: 4.0.18
       '@astrojs/sitemap':
-        specifier: ^3.7.2
+        specifier: 3.7.2
         version: 3.7.2
       '@cloudfour/image-compare':
-        specifier: ^1.0.5
+        specifier: 1.0.5
         version: 1.0.5
       '@fontsource-variable/ibm-plex-sans':
-        specifier: ^5.2.8
+        specifier: 5.2.8
         version: 5.2.8
       '@fontsource-variable/lora':
-        specifier: ^5.2.8
+        specifier: 5.2.8
         version: 5.2.8
       '@fontsource/ibm-plex-mono':
-        specifier: ^5.2.7
+        specifier: 5.2.7
         version: 5.2.7
       astro:
-        specifier: ^6.3.5
+        specifier: 6.3.5
         version: 6.3.5(@netlify/blobs@10.7.8)(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0)
       common:
         specifier: workspace:*
         version: link:../common
       drizzle-orm:
-        specifier: ^0.45.2
+        specifier: 0.45.2
         version: 0.45.2(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.1)(pg@8.21.0)(postgres@3.4.9)
       postgres:
-        specifier: ^3.4.9
+        specifier: 3.4.9
         version: 3.4.9
       rehype-slug:
-        specifier: ^6.0.0
+        specifier: 6.0.0
         version: 6.0.0
       sharp:
-        specifier: ^0.34.5
+        specifier: 0.34.5
         version: 0.34.5
       shiki:
-        specifier: ^4.0.2
+        specifier: 4.0.2
         version: 4.0.2
       ua-parser-js:
-        specifier: ^2.0.9
+        specifier: 2.0.9
         version: 2.0.9
       unist-util-visit:
-        specifier: ^5.1.0
+        specifier: 5.1.0
         version: 5.1.0
       web-vitals:
-        specifier: ^5.2.0
+        specifier: 5.2.0
         version: 5.2.0
     devDependencies:
       '@astrojs/check':
-        specifier: ^0.9.9
+        specifier: 0.9.9
         version: 0.9.9(prettier@3.8.3)(typescript@6.0.3)
       accented:
         specifier: workspace:*
         version: link:../accented
       drizzle-kit:
-        specifier: ^0.31.10
+        specifier: 0.31.10
         version: 0.31.10
       netlify-cli:
-        specifier: ^26.0.2
+        specifier: 26.0.2
         version: 26.0.2(@types/node@25.9.1)(picomatch@4.0.4)(rollup@4.60.4)
 
 packages:


### PR DESCRIPTION
* Bump axe-core to 4.11.4
* Pin most dependency versions
* Improve changelog format