### PR TITLE
Fix: scan would run on full context if mutation happened out of context

### DIFF
--- a/.changeset/gentle-meals-watch.md
+++ b/.changeset/gentle-meals-watch.md
@@ -1,0 +1,5 @@
+---
+"accented": patch
+---
+
+Fix: scan would run on the full document if a mutation happened outside of context

--- a/packages/accented/src/scanner.ts
+++ b/packages/accented/src/scanner.ts
@@ -102,16 +102,16 @@ export function createScanner(
       try {
         // Run the scan against the limited context (only the mutated
         // nodes, filtered to those within the user-provided context). Skip if no
-        // limited-context rules are active.
+        // limited-context rules are active or if there's nothing to scan.
         limitedContextResult =
-          limitedContextRules.size > 0
+          limitedContextRules.size > 0 && limitedContext.include.length > 0
             ? await axe.run(limitedContext, {
                 ...baseAxeOptions,
                 runOnly: { type: 'rule', values: [...limitedContextRules] },
               })
             : undefined;
 
-        // Run the supplemental scan against the full context so that ancestor-
+        // Run the scan against the full context so that ancestor-
         // dependent rules always see the complete DOM. Skip if none are active.
         fullContextResult =
           fullContextRules.size > 0

--- a/packages/devapp/test/main.spec.ts
+++ b/packages/devapp/test/main.spec.ts
@@ -1168,6 +1168,18 @@ test.describe('Accented', () => {
         await expect(countWithinSectionAfterExclude).toBeGreaterThan(0);
         await expect(countWithinSectionAfterExclude).toBeLessThan(countWithinSection);
       });
+
+      test('mutations outside the scoped context don’t cause new issues to be reported', async ({
+        page,
+      }) => {
+        await page.goto('?axe-context-selector=%23fixed-position&throttle-wait=0');
+        await page.locator(accentedSelector).first().waitFor();
+        const initialCount = await page.locator(accentedSelector).count();
+        await page.getByRole('button', { name: 'Add text to button' }).click();
+        await page.waitForTimeout(500);
+        const finalCount = await page.locator(accentedSelector).count();
+        expect(finalCount).toBe(initialCount);
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #513


