### PR TITLE
Try fixing a dependabot / github package registry bug

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,9 @@
 save-exact=true
+
+# A fix for a dependabot error:
+# dependabot would hit the github registry (instead of the npmjs one)
+# by default, and some @types/ packages would be stale there,
+# resulting in a "version not found" error.
+# I'm still not sure what makes dependabot not check npmjs.org by default,
+# but this line solves the problem.
+@types:registry=https://registry.npmjs.org/


### PR DESCRIPTION
A fix for a dependabot error:
dependabot would hit the github registry (instead of the npmjs one)
by default, and some @types/ packages would be stale there,
resulting in a "version not found" error.
I'm still not sure what makes dependabot not check npmjs.org by default,
but hopefully this line solves the problem.