### PR TITLE
Make website pages static and fix some 500 errors

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -16,7 +16,6 @@ export default defineConfig({
   publicDir: './public',
   site: 'https://accented.dev',
   trailingSlash: 'never',
-  output: 'server',
 
   build: {
     format: 'file',

--- a/packages/website/src/components/TableOfContents.astro
+++ b/packages/website/src/components/TableOfContents.astro
@@ -5,7 +5,7 @@ type Heading = {
   text: string;
 };
 
-const matches = import.meta.glob('~/pages/*.md(x)?', { eager: true });
+const matches = import.meta.glob('~/pages/*.{md,mdx}', { eager: true });
 const pages = Object.values(matches) as Array<{ url: string; getHeadings: () => Array<Heading> }>;
 const currentPage = pages.find(
   (page) => page.url === Astro.url.pathname.replace(/^(.+)\.html$/, '$1'),


### PR DESCRIPTION
It turned out that the following pages have been broken since #459 
The reason was that the globbing I was using in the `TableOfContents` component was not supported by the globbing library that the upgraded version of Vite started using: https://vite.dev/guide/migration#advanced